### PR TITLE
Use seed in last dense layer of DeepFM

### DIFF
--- a/deepctr/estimator/models/deepfm.py
+++ b/deepctr/estimator/models/deepfm.py
@@ -10,6 +10,8 @@ Reference:
 
 import tensorflow as tf
 
+from tensorflow.python.keras.initializers import glorot_normal
+
 from ..feature_column import get_linear_logit, input_from_feature_columns
 from ..utils import deepctr_model_fn, DNN_SCOPE_NAME, variable_scope
 from ...layers.core import DNN

--- a/deepctr/estimator/models/deepfm.py
+++ b/deepctr/estimator/models/deepfm.py
@@ -66,7 +66,7 @@ def DeepFMEstimator(linear_feature_columns, dnn_feature_columns, dnn_hidden_unit
             dnn_output = DNN(dnn_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout,
                              dnn_use_bn, seed)(dnn_input, training=train_flag)
             dnn_logit = tf.keras.layers.Dense(
-                1, use_bias=False, activation=None)(dnn_output)
+                1, use_bias=False, activation=None, kernel_initializer=glorot_normal(seed=seed))(dnn_output)
 
         logits = linear_logits + fm_logit + dnn_logit
 

--- a/deepctr/models/deepfm.py
+++ b/deepctr/models/deepfm.py
@@ -12,6 +12,8 @@ from itertools import chain
 
 import tensorflow as tf
 
+from tensorflow.python.keras.initializers import glorot_normal
+
 from ..feature_column import build_input_features, get_linear_logit, DEFAULT_GROUP_NAME, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN
 from ..layers.interaction import FM

--- a/deepctr/models/deepfm.py
+++ b/deepctr/models/deepfm.py
@@ -57,7 +57,7 @@ def DeepFM(linear_feature_columns, dnn_feature_columns, fm_group=[DEFAULT_GROUP_
     dnn_output = DNN(dnn_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout,
                      dnn_use_bn, seed)(dnn_input)
     dnn_logit = tf.keras.layers.Dense(
-        1, use_bias=False, activation=None)(dnn_output)
+        1, use_bias=False, activation=None, kernel_initializer=glorot_normal(seed=seed))(dnn_output)
 
     final_logit = add_func([linear_logit, fm_logit, dnn_logit])
 


### PR DESCRIPTION
Hey, I found that the DeepFM model does not initialize in a reproducible way. I saw that the last dense layer's weights are not initialized with a seed, so I added a kernel initializer to it (the bias is zero-initialized by default, so no need to change anything there). 