### PR TITLE
Add open in dsw

### DIFF
--- a/docs/source/Quick-Start.md
+++ b/docs/source/Quick-Start.md
@@ -1,5 +1,6 @@
 # Quick-Start
 
+[![Open In DSW](https://pai-public-data.oss-cn-beijing.aliyuncs.com/EN-pai-dsw.svg)](https://dsw-dev.data.aliyun.com/#/?fileUrl=https://pai-public-data.oss-cn-beijing.aliyuncs.com/deep-ctr/Getting-started-4-steps-to-DeepCTR.ipynb&fileName=Getting-started-4-steps-to-DeepCTR.ipynb)
 ## Installation Guide
 Now `deepctr` is available for python `2.7 `and `3.5, 3.6, 3.7`.  
 `deepctr` depends on tensorflow, you can specify to install the cpu version or gpu version through `pip`.


### PR DESCRIPTION
Add open in DSW, which provides a free computing environment for DeepCTR users.