### PR TITLE
New Feature: Modify the Hash layer to support the lookup table

### DIFF
--- a/deepctr/feature_column.py
+++ b/deepctr/feature_column.py
@@ -15,12 +15,12 @@ DEFAULT_GROUP_NAME = "default_group"
 
 
 class SparseFeat(namedtuple('SparseFeat',
-                            ['name', 'vocabulary_size', 'embedding_dim', 'use_hash', 'dtype', 'embeddings_initializer',
+                            ['name', 'vocabulary_size', 'embedding_dim', 'use_hash', 'vocabulary_path', 'dtype', 'embeddings_initializer',
                              'embedding_name',
                              'group_name', 'trainable'])):
     __slots__ = ()
 
-    def __new__(cls, name, vocabulary_size, embedding_dim=4, use_hash=False, dtype="int32", embeddings_initializer=None,
+    def __new__(cls, name, vocabulary_size, embedding_dim=4, use_hash=False, vocabulary_path=None, dtype="int32", embeddings_initializer=None,
                 embedding_name=None,
                 group_name=DEFAULT_GROUP_NAME, trainable=True):
 
@@ -32,7 +32,7 @@ class SparseFeat(namedtuple('SparseFeat',
         if embedding_name is None:
             embedding_name = name
 
-        return super(SparseFeat, cls).__new__(cls, name, vocabulary_size, embedding_dim, use_hash, dtype,
+        return super(SparseFeat, cls).__new__(cls, name, vocabulary_size, embedding_dim, use_hash, vocabulary_path, dtype,
                                               embeddings_initializer,
                                               embedding_name, group_name, trainable)
 
@@ -63,6 +63,10 @@ class VarLenSparseFeat(namedtuple('VarLenSparseFeat',
     @property
     def use_hash(self):
         return self.sparsefeat.use_hash
+
+    @property
+    def vocabulary_path(self):
+        return self.sparsefeat.vocabulary_path
 
     @property
     def dtype(self):

--- a/deepctr/inputs.py
+++ b/deepctr/inputs.py
@@ -51,7 +51,7 @@ def get_embedding_vec_list(embedding_dict, input_dict, sparse_feature_columns, r
         feat_name = fg.name
         if len(return_feat_list) == 0 or feat_name in return_feat_list:
             if fg.use_hash:
-                lookup_idx = Hash(fg.vocabulary_size, mask_zero=(feat_name in mask_feat_list))(input_dict[feat_name])
+                lookup_idx = Hash(fg.vocabulary_size, mask_zero=(feat_name in mask_feat_list), vocabulary_path=fg.vocabulary_path)(input_dict[feat_name])
             else:
                 lookup_idx = input_dict[feat_name]
 
@@ -80,7 +80,7 @@ def embedding_lookup(sparse_embedding_dict, sparse_input_dict, sparse_feature_co
         embedding_name = fc.embedding_name
         if (len(return_feat_list) == 0 or feature_name in return_feat_list):
             if fc.use_hash:
-                lookup_idx = Hash(fc.vocabulary_size, mask_zero=(feature_name in mask_feat_list))(
+                lookup_idx = Hash(fc.vocabulary_size, mask_zero=(feature_name in mask_feat_list), vocabulary_path=fc.vocabulary_path)(
                     sparse_input_dict[feature_name])
             else:
                 lookup_idx = sparse_input_dict[feature_name]
@@ -97,7 +97,7 @@ def varlen_embedding_lookup(embedding_dict, sequence_input_dict, varlen_sparse_f
         feature_name = fc.name
         embedding_name = fc.embedding_name
         if fc.use_hash:
-            lookup_idx = Hash(fc.vocabulary_size, mask_zero=True)(sequence_input_dict[feature_name])
+            lookup_idx = Hash(fc.vocabulary_size, mask_zero=True, vocabulary_path=fc.vocabulary_path)(sequence_input_dict[feature_name])
         else:
             lookup_idx = sequence_input_dict[feature_name]
         varlen_embedding_vec_dict[feature_name] = embedding_dict[embedding_name](lookup_idx)

--- a/deepctr/layers/core.py
+++ b/deepctr/layers/core.py
@@ -68,8 +68,8 @@ class LocalActivationUnit(Layer):
                              'inputs of a two inputs with shape (None,1,embedding_size) and (None,T,embedding_size)'
                              'Got different shapes: %s,%s' % (input_shape[0], input_shape[1]))
         size = 4 * \
-               int(input_shape[0][-1]
-                   ) if len(self.hidden_units) == 0 else self.hidden_units[-1]
+            int(input_shape[0][-1]
+                ) if len(self.hidden_units) == 0 else self.hidden_units[-1]
         self.kernel = self.add_weight(shape=(size, 1),
                                       initializer=glorot_normal(
                                           seed=self.seed),
@@ -77,9 +77,6 @@ class LocalActivationUnit(Layer):
         self.bias = self.add_weight(
             shape=(1,), initializer=Zeros(), name="bias")
         self.dnn = DNN(self.hidden_units, self.activation, self.l2_reg, self.dropout_rate, self.use_bn, seed=self.seed)
-
-        self.dense = tf.keras.layers.Lambda(lambda x: tf.nn.bias_add(tf.tensordot(
-            x[0], x[1], axes=(-1, 0)), x[2]))
 
         super(LocalActivationUnit, self).build(
             input_shape)  # Be sure to call this somewhere!
@@ -96,7 +93,7 @@ class LocalActivationUnit(Layer):
 
         att_out = self.dnn(att_input, training=training)
 
-        attention_score = self.dense([att_out, self.kernel, self.bias])
+        attention_score = tf.nn.bias_add(tf.tensordot(att_out, self.kernel, axes=(-1, 0)), self.bias)
 
         return attention_score
 

--- a/deepctr/layers/sequence.py
+++ b/deepctr/layers/sequence.py
@@ -633,8 +633,7 @@ class PositionEncoding(Layer):
         _, T, num_units = input_shape.as_list()  # inputs.get_shape().as_list()
         # First part of the PE function: sin and cos argument
         position_enc = np.array([
-            [pos / np.power(10000, 2. * i / num_units)
-             for i in range(num_units)]
+            [pos / np.power(10000, 2. * (i//2) / num_units) for i in range(num_units)]
             for pos in range(T)])
 
         # Second part, apply the cosine to even columns and sin to odds.

--- a/deepctr/layers/sequence.py
+++ b/deepctr/layers/sequence.py
@@ -561,7 +561,7 @@ class Transformer(Layer):
             try:
                 outputs = tf.matrix_set_diag(outputs, tf.ones_like(outputs)[
                     :, :, 0] * (-2 ** 32 + 1))
-            except:
+            except AttributeError as e:
                 outputs = tf.compat.v1.matrix_set_diag(outputs, tf.ones_like(outputs)[
                     :, :, 0] * (-2 ** 32 + 1))
 

--- a/deepctr/layers/sequence.py
+++ b/deepctr/layers/sequence.py
@@ -560,10 +560,10 @@ class Transformer(Layer):
         if self.blinding:
             try:
                 outputs = tf.matrix_set_diag(outputs, tf.ones_like(outputs)[
-                                                      :, :, 0] * (-2 ** 32 + 1))
+                    :, :, 0] * (-2 ** 32 + 1))
             except:
                 outputs = tf.compat.v1.matrix_set_diag(outputs, tf.ones_like(outputs)[
-                                                                :, :, 0] * (-2 ** 32 + 1))
+                    :, :, 0] * (-2 ** 32 + 1))
 
         outputs -= reduce_max(outputs, axis=-1, keep_dims=True)
         outputs = softmax(outputs)
@@ -640,7 +640,8 @@ class PositionEncoding(Layer):
         # Second part, apply the cosine to even columns and sin to odds.
         position_enc[:, 0::2] = np.sin(position_enc[:, 0::2])  # dim 2i
         position_enc[:, 1::2] = np.cos(position_enc[:, 1::2])  # dim 2i+1
-
+        if self.zero_pad:
+            position_enc[0, :] = np.zeros(num_units)
         self.lookup_table = self.add_weight("lookup_table", (T, num_units),
                                             initializer=tf.initializers.identity(position_enc),
                                             trainable=self.pos_embedding_trainable)
@@ -651,13 +652,7 @@ class PositionEncoding(Layer):
     def call(self, inputs, mask=None):
         _, T, num_units = inputs.get_shape().as_list()
         position_ind = tf.expand_dims(tf.range(T), 0)
-
-        if self.zero_pad:
-            self.lookup_table = tf.concat((tf.zeros(shape=[1, num_units]),
-                                           self.lookup_table[1:, :]), 0)
-
         outputs = tf.nn.embedding_lookup(self.lookup_table, position_ind)
-
         if self.scale:
             outputs = outputs * num_units ** 0.5
         return outputs + inputs

--- a/deepctr/layers/utils.py
+++ b/deepctr/layers/utils.py
@@ -25,9 +25,37 @@ class NoMask(tf.keras.layers.Layer):
 
 
 class Hash(tf.keras.layers.Layer):
-    """
-    hash the input to [0,num_buckets)
-    if mask_zero = True,0 or 0.0 will be set to 0,other value will be set in range[1,num_buckets)
+    """Looks up keys in a table when setup `vocabulary_path`, which outputs the corresponding values.
+    If `vocabulary_path` is not set, `Hash` will hash the input to [0,num_buckets). When `mask_zero` = True,
+    input value `0` or `0.0` will be set to `0`, and other value will be set in range [1,num_buckets).
+
+    The following snippet initializes a `Hash` with `vocabulary_path` file with the first column as keys and
+    second column as values:
+
+    * `1,emerson`
+    * `2,lake`
+    * `3,palmer`
+
+    >>> hash = Hash(
+    ...   num_buckets=3+1,
+    ...   vocabulary_path=filename,
+    ...   default_value=0)
+    >>> hash(tf.constant('lake')).numpy()
+    2
+    >>> hash(tf.constant('lakeemerson')).numpy()
+    0
+
+    Args:
+        num_buckets: An `int` that is >= 1. The number of buckets or the vocabulary size + 1 
+            when `vocabulary_path` is setup.
+        mask_zero: default is False. The `Hash` value will hash input `0` or `0.0` to value `0` when 
+            the `mask_zero` is `True`. `mask_zero` is not used when `vocabulary_path` is setup.
+        vocabulary_path: default `None`. The `CSV` text file path of the vocabulary hash, which contains 
+            two columns seperated by delimiter `comma`, the first column is the value and the second is 
+            the key. The key data type is `string`, the value data type is `int`. The path must
+            be accessible from wherever `Hash` is initialized.
+        default_value: default '0'. The default value if a key is missing in the table.
+        **kwargs: Additional keyword arguments.
     """
 
     def __init__(self, num_buckets, mask_zero=False, vocabulary_path=None, default_value=0, **kwargs):

--- a/deepctr/layers/utils.py
+++ b/deepctr/layers/utils.py
@@ -8,10 +8,10 @@ Author:
 import tensorflow as tf
 from tensorflow.python.keras.layers import Flatten
 from tensorflow.python.ops.lookup_ops import TextFileInitializer
-if hasattr(tf, 'VERSION') and tf.VERSION.title() <= '1.4.0':
-    from tensorflow.python.ops.lookup_ops import HashTable as StaticHashTable
-else:
+try:
     from tensorflow.python.ops.lookup_ops import StaticHashTable
+except:
+    from tensorflow.python.ops.lookup_ops import HashTable as StaticHashTable
 
 
 class NoMask(tf.keras.layers.Layer):

--- a/deepctr/layers/utils.py
+++ b/deepctr/layers/utils.py
@@ -46,12 +46,12 @@ class Hash(tf.keras.layers.Layer):
     0
 
     Args:
-        num_buckets: An `int` that is >= 1. The number of buckets or the vocabulary size + 1 
+        num_buckets: An `int` that is >= 1. The number of buckets or the vocabulary size + 1
             when `vocabulary_path` is setup.
-        mask_zero: default is False. The `Hash` value will hash input `0` or `0.0` to value `0` when 
+        mask_zero: default is False. The `Hash` value will hash input `0` or `0.0` to value `0` when
             the `mask_zero` is `True`. `mask_zero` is not used when `vocabulary_path` is setup.
-        vocabulary_path: default `None`. The `CSV` text file path of the vocabulary hash, which contains 
-            two columns seperated by delimiter `comma`, the first column is the value and the second is 
+        vocabulary_path: default `None`. The `CSV` text file path of the vocabulary hash, which contains
+            two columns seperated by delimiter `comma`, the first column is the value and the second is
             the key. The key data type is `string`, the value data type is `int`. The path must
             be accessible from wherever `Hash` is initialized.
         default_value: default '0'. The default value if a key is missing in the table.

--- a/deepctr/layers/utils.py
+++ b/deepctr/layers/utils.py
@@ -7,7 +7,11 @@ Author:
 """
 import tensorflow as tf
 from tensorflow.python.keras.layers import Flatten
-from tensorflow.python.ops.lookup_ops import TextFileInitializer, StaticHashTable
+from tensorflow.python.ops.lookup_ops import TextFileInitializer
+if hasattr(tf, 'VERSION') and tf.VERSION.title() <= '1.4.0':
+    from tensorflow.python.ops.lookup_ops import HashTable as StaticHashTable
+else:
+    from tensorflow.python.ops.lookup_ops import StaticHashTable
 
 
 class NoMask(tf.keras.layers.Layer):

--- a/deepctr/layers/utils.py
+++ b/deepctr/layers/utils.py
@@ -10,7 +10,7 @@ from tensorflow.python.keras.layers import Flatten
 from tensorflow.python.ops.lookup_ops import TextFileInitializer
 try:
     from tensorflow.python.ops.lookup_ops import StaticHashTable
-except:
+except ImportError as e:
     from tensorflow.python.ops.lookup_ops import HashTable as StaticHashTable
 
 

--- a/deepctr/layers/utils.py
+++ b/deepctr/layers/utils.py
@@ -7,6 +7,7 @@ Author:
 """
 import tensorflow as tf
 from tensorflow.python.keras.layers import Flatten
+from tensorflow.python.ops.lookup_ops import TextFileInitializer, StaticHashTable
 
 
 class NoMask(tf.keras.layers.Layer):
@@ -64,8 +65,8 @@ class Hash(tf.keras.layers.Layer):
         self.vocabulary_path = vocabulary_path
         self.default_value = default_value
         if self.vocabulary_path:
-            initializer = tf.lookup.TextFileInitializer(vocabulary_path, 'string', 1, 'int64', 0, delimiter=',')
-            self.hash_table = tf.lookup.StaticHashTable(initializer, default_value=self.default_value)
+            initializer = TextFileInitializer(vocabulary_path, 'string', 1, 'int64', 0, delimiter=',')
+            self.hash_table = StaticHashTable(initializer, default_value=self.default_value)
         super(Hash, self).__init__(**kwargs)
 
     def build(self, input_shape):

--- a/deepctr/layers/utils.py
+++ b/deepctr/layers/utils.py
@@ -97,6 +97,9 @@ class Hash(tf.keras.layers.Layer):
 
         return hash_x
 
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
     def get_config(self, ):
         config = {'num_buckets': self.num_buckets, 'mask_zero': self.mask_zero, 'vocabulary_path': self.vocabulary_path, 'default_value': self.default_value}
         base_config = super(Hash, self).get_config()

--- a/docs/source/Features.md
+++ b/docs/source/Features.md
@@ -23,12 +23,13 @@ DNN based CTR prediction models usually have following 4 modules:
 
 ## Feature Columns
 ### SparseFeat
-``SparseFeat`` is a namedtuple with signature ``SparseFeat(name, vocabulary_size, embedding_dim, use_hash, dtype, embeddings_initializer, embedding_name, group_name, trainable)``
+``SparseFeat`` is a namedtuple with signature ``SparseFeat(name, vocabulary_size, embedding_dim, use_hash, vocabulary_path, dtype, embeddings_initializer, embedding_name, group_name, trainable)``
 
 - name : feature name
 - vocabulary_size : number of unique feature values for sprase feature or hashing space when `use_hash=True`
 - embedding_dim : embedding dimension
-- use_hash : defualt `False`.If `True` the input will be hashed to space of size `vocabulary_size`.
+- use_hash : default `False`.If `True` the input will be hashed to space of size `vocabulary_size`.
+- vocabulary_path : default `None`. The `CSV` text file path of the vocabulary table used by `tf.lookup.TextFileInitializer`, which assigns one entry in the table for each line in the file. One entry contains two columns seperated by comma, the first is the value column, the second is the key column. The `0` value is reserved to use if a key is missing in the table, so hash value need start from `1`.
 - dtype : default `int32`.dtype of input tensor.
 - embeddings_initializer : initializer for the `embeddings` matrix.
 - embedding_name : default `None`. If None, the embedding_name will be same as `name`.

--- a/examples/run_multivalue_movielens_vocab_hash.py
+++ b/examples/run_multivalue_movielens_vocab_hash.py
@@ -1,0 +1,114 @@
+import functools
+import os
+import numpy as np
+import pandas as pd
+import shutil
+from tensorflow.python.keras.preprocessing.sequence import pad_sequences
+
+from deepctr.feature_column import SparseFeat, VarLenSparseFeat, get_feature_names
+from deepctr.models import DeepFM
+
+
+def init_vocab(df, tmpdir):
+    """initialize the vacabulary file of the sparse features
+    """
+    vocab_size = {}
+
+    df_user_id = df.user_id.drop_duplicates().dropna().sort_values().reset_index().drop(columns='index')
+    df_user_id.index += 1
+    df_user_id.to_csv(f'{tmpdir}/user_id.csv', sep=',', index=True, header=False)
+    # must set to vocabulary size pluse 1, because 0 is used for miss of has and mask, same below
+    vocab_size['user_id'] = len(df_user_id) + 1
+
+    df_movie_id = df.movie_id.drop_duplicates().dropna().sort_values().reset_index().drop(
+        columns='index')
+    df_movie_id.index += 1
+    df_movie_id.to_csv(f'{tmpdir}/movie_id.csv', sep=',', index=True, header=False)
+    vocab_size['movie_id'] = len(df_movie_id) + 1
+
+    df_genre = pd.DataFrame({
+        'genre': list(set(functools.reduce(lambda x, y: x + y, df.genres.str.split('|'))))
+    }).genre.sort_values()
+    df_genre.index += 1
+    df_genre.to_csv(f'{tmpdir}/genre.csv', sep=',', index=True, header=False)
+    vocab_size['genre'] = len(df_genre) + 1
+
+    df_gender = df.gender.drop_duplicates().replace(
+        r'^\s*$', np.nan,
+        regex=True).dropna().sort_values().reset_index().drop(
+            columns='index')
+    df_gender.index += 1
+    df_gender.to_csv(f'{tmpdir}/gender.csv', sep=',', index=True, header=False)
+    vocab_size['gender'] = len(df_gender) + 1
+
+    df_age = df.age.drop_duplicates().dropna().sort_values().reset_index().drop(columns='index')
+    df_age.index += 1
+    df_age.to_csv(f'{tmpdir}/age.csv', sep=',', index=True, header=False)
+    vocab_size['age'] = len(df_age) + 1
+
+    df_occupation = df.occupation.drop_duplicates().replace(
+        r'^\s*$', np.nan,
+        regex=True).dropna().sort_values().reset_index().drop(
+            columns='index')
+    df_occupation.index += 1
+    df_occupation.to_csv(f'{tmpdir}/occupation.csv', sep=',', index=True, header=False)
+    vocab_size['occupation'] = len(df_occupation) + 1
+
+    df_zip = df.zip.drop_duplicates().replace(
+        r'^\s*$', np.nan,
+        regex=True).dropna().sort_values().reset_index().drop(columns='index')
+    df_zip.index += 1
+    df_zip.to_csv(f'{tmpdir}/zip.csv', sep=',', index=True, header=False)
+    vocab_size['zip'] = len(df_zip) + 1
+    return vocab_size
+
+
+if __name__ == "__main__":
+    # change this to where the movielens dataset and work directory is
+    workdir = os.path.dirname(__file__)
+    data = pd.read_csv(f"{workdir}/movielens_sample.txt")
+
+    metadir = f'{workdir}/meta'
+    if not os.path.exists(metadir):
+        os.mkdir(metadir)
+    vocab_size = init_vocab(data, metadir)
+
+    sparse_features = ["movie_id", "user_id",
+                       "gender", "age", "occupation", "zip", ]
+
+    data[sparse_features] = data[sparse_features].astype(str)
+    target = ['rating']
+
+    # 1.Use hashing encoding on the fly for sparse features,and process sequence features
+
+    genres_list = list(map(lambda x: x.split('|'), data['genres'].values))
+    genres_length = np.array(list(map(len, genres_list)))
+    max_len = max(genres_length)
+
+    # Notice : padding=`post`
+    genres_list = pad_sequences(genres_list, maxlen=max_len, padding='post', dtype=str, value=0)
+
+    # 2.set hashing space for each sparse field and generate feature config for sequence feature
+
+    fixlen_feature_columns = [SparseFeat(feat, vocab_size[feat], embedding_dim=4, use_hash=True, vocabulary_path=f'{metadir}/{feat}.csv', dtype='string')
+                              for feat in sparse_features]
+    varlen_feature_columns = [
+        VarLenSparseFeat(SparseFeat('genres', vocabulary_size=vocab_size['genre'], embedding_dim=4, use_hash=True, vocabulary_path=f'{metadir}/genre.csv', dtype="string"),
+                         maxlen=max_len, combiner='mean',
+                         )]  # Notice : value 0 is for padding for sequence input feature
+    linear_feature_columns = fixlen_feature_columns + varlen_feature_columns
+    dnn_feature_columns = fixlen_feature_columns + varlen_feature_columns
+    feature_names = get_feature_names(linear_feature_columns + dnn_feature_columns)
+
+    # 3.generate input data for model
+    model_input = {name: data[name] for name in feature_names}
+    model_input['genres'] = genres_list
+
+    # 4.Define Model,compile and train
+    model = DeepFM(linear_feature_columns, dnn_feature_columns, task='regression')
+    model.compile("adam", "mse", metrics=['mse'], )
+    history = model.fit(model_input, data[target].values,
+                        batch_size=256, epochs=10, verbose=2, validation_split=0.2, )
+
+    if os.path.exists(metadir):
+        shutil.rmtree(metadir)

--- a/examples/run_multivalue_movielens_vocab_hash.py
+++ b/examples/run_multivalue_movielens_vocab_hash.py
@@ -8,7 +8,7 @@ import shutil
 from tensorflow.python.keras.preprocessing.sequence import pad_sequences
 try:
     import tensorflow.compat.v1 as tf
-except:
+except ImportError as e:
     import tensorflow as tf
 
 

--- a/examples/run_multivalue_movielens_vocab_hash.py
+++ b/examples/run_multivalue_movielens_vocab_hash.py
@@ -7,6 +7,8 @@ import pandas as pd
 import shutil
 from tensorflow.python.keras.preprocessing.sequence import pad_sequences
 import tensorflow as tf
+if hasattr(tf, 'version') and tf.version.VERSION >= '1.14.0':
+    import tensorflow.compat.v1 as tf
 
 
 def init_vocab(df, tmpdir):
@@ -108,8 +110,8 @@ if __name__ == "__main__":
     model = DeepFM(linear_feature_columns, dnn_feature_columns, task='regression')
     model.compile("adam", "mse", metrics=['mse'], )
     if not hasattr(tf, 'version') or tf.version.VERSION < '2.0.0':
-        with tf.compat.v1.Session() as sess:
-            sess.run(tf.compat.v1.tables_initializer())
+        with tf.Session() as sess:
+            sess.run(tf.tables_initializer())
             history = model.fit(model_input, data[target].values,
                                 batch_size=256, epochs=10, verbose=2, validation_split=0.2, )
     else:

--- a/examples/run_multivalue_movielens_vocab_hash.py
+++ b/examples/run_multivalue_movielens_vocab_hash.py
@@ -6,9 +6,10 @@ import numpy as np
 import pandas as pd
 import shutil
 from tensorflow.python.keras.preprocessing.sequence import pad_sequences
-import tensorflow as tf
-if hasattr(tf, 'version') and tf.version.VERSION >= '1.14.0':
+try:
     import tensorflow.compat.v1 as tf
+except:
+    import tensorflow as tf
 
 
 def init_vocab(df, tmpdir):

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -1,6 +1,8 @@
 from deepctr.models import DeepFM
-from deepctr.feature_column import SparseFeat, DenseFeat,get_feature_names
+from deepctr.feature_column import SparseFeat, DenseFeat, VarLenSparseFeat, get_feature_names
 import numpy as np
+
+
 def test_long_dense_vector():
 
     feature_columns = [SparseFeat('user_id', 4, ), SparseFeat('item_id', 5, ), DenseFeat("pic_vec", 5)]
@@ -17,3 +19,11 @@ def test_long_dense_vector():
     model = DeepFM(feature_columns, feature_columns[:-1])
     model.compile('adagrad', 'binary_crossentropy')
     model.fit(model_input, label)
+
+
+def test_feature_column_sparsefeat_vocabulary_path():
+    vocab_path = "./dummy_test.csv"
+    sf = SparseFeat('user_id', 4, vocabulary_path=vocab_path)
+    assert sf.vocabulary_path == vocab_path
+    vlsf = VarLenSparseFeat(sf, 6)
+    assert vlsf.vocabulary_path == vocab_path

--- a/tests/layers/sequence_test.py
+++ b/tests/layers/sequence_test.py
@@ -79,8 +79,6 @@ def test_BiLSTM(merge_mode):
 
 
 def test_Transformer():
-    if tf.__version__ >= '2.0.0':
-        tf.compat.v1.disable_eager_execution()  # todo
     with CustomObjectScope({'Transformer': sequence.Transformer}):
         layer_test(sequence.Transformer,
                    kwargs={'att_embedding_size': 1, 'head_num': 8, 'use_layer_norm': True, 'supports_masking': False,
@@ -102,7 +100,7 @@ def test_KMaxPooling():
      ]
 )
 def test_PositionEncoding(pos_embedding_trainable, zero_pad):
-    with CustomObjectScope({'PositionEncoding': sequence.PositionEncoding}):
+    with CustomObjectScope({'PositionEncoding': sequence.PositionEncoding, "tf": tf}):
         layer_test(sequence.PositionEncoding,
                    kwargs={'pos_embedding_trainable': pos_embedding_trainable, 'zero_pad': zero_pad},
                    input_shape=(BATCH_SIZE, SEQ_LENGTH, EMBEDDING_SIZE))

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -21,9 +21,6 @@ def test_Hash(num_buckets, mask_zero, vocabulary_path, input_data, expected_outp
     if tf.version.VERSION < '2.0.0':
         return
     with CustomObjectScope({'Hash': Hash}):
-        sess = tf.compat.v1.get_default_session()
-        if sess:
-            sess.run(tf.compat.v1.tables_initializer())
         layer_test(Hash, kwargs={'num_buckets': num_buckets, 'mask_zero': mask_zero, 'vocabulary_path': vocabulary_path},
                    input_dtype=tf.string, input_data=np.array(input_data, dtype='str'),
                    expected_output_dtype=tf.int64, expected_output=expected_output)

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -1,0 +1,25 @@
+import tensorflow as tf
+from deepctr.layers.utils import Hash
+from deepctr.feature_column import SparseFeat
+
+
+def test_hash():
+
+    vocab_path = "./tests/layers/vocabulary_example.csv"
+    vocab_size = 3+1
+    sf = SparseFeat('user_id', vocab_size, vocabulary_path=vocab_path)
+    hash = Hash(num_buckets=sf.vocabulary_size, vocabulary_path=sf.vocabulary_path, default_value=0)
+    assert hash(tf.constant('lake')).numpy() == 1
+    assert hash(tf.constant('johnson')).numpy() == 3
+    assert hash(tf.constant('lakemerson')).numpy() == 0
+
+    hash_val = tf.strings.to_hash_bucket_fast('lakemerson', vocab_size).numpy()
+    hash = Hash(num_buckets=vocab_size)
+    assert hash(tf.constant('lakemerson')).numpy() == hash_val
+
+    hash_val = tf.strings.to_hash_bucket_fast('lakemerson', vocab_size-1).numpy() + 1
+    hash = Hash(num_buckets=vocab_size, mask_zero=True)
+    assert hash(tf.constant('lakemerson')).numpy() == hash_val
+
+    hash = Hash(num_buckets=vocab_size, mask_zero=True)
+    assert hash(tf.constant('0')).numpy() == 0

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -21,6 +21,9 @@ def test_Hash(num_buckets, mask_zero, vocabulary_path, input_data, expected_outp
     if tf.version.VERSION < '2.0.0':
         return
     with CustomObjectScope({'Hash': Hash}):
+        sess = tf.compat.v1.get_default_session()
+        if sess:
+            sess.run(tf.compat.v1.tables_initializer())
         layer_test(Hash, kwargs={'num_buckets': num_buckets, 'mask_zero': mask_zero, 'vocabulary_path': vocabulary_path},
                    input_dtype=tf.string, input_data=np.array(input_data, dtype='str'),
                    expected_output_dtype=tf.int64, expected_output=expected_output)

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -4,7 +4,11 @@ from deepctr.feature_column import SparseFeat
 
 
 def test_hash():
-
+    try:
+        import tensorflow.python.ops.numpy_ops.np_config as np_config
+        np_config.enable_numpy_behavior()
+    finally:
+        pass
     vocab_path = "./tests/layers/vocabulary_example.csv"
     vocab_size = 3+1
     sf = SparseFeat('user_id', vocab_size, vocabulary_path=vocab_path)

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -4,26 +4,24 @@ from deepctr.feature_column import SparseFeat
 
 
 def test_hash():
-    try:
-        import tensorflow.python.ops.numpy_ops.np_config as np_config
-        np_config.enable_numpy_behavior()
-    finally:
-        pass
     vocab_path = "./tests/layers/vocabulary_example.csv"
     vocab_size = 3+1
     sf = SparseFeat('user_id', vocab_size, vocabulary_path=vocab_path)
     hash = Hash(num_buckets=sf.vocabulary_size, vocabulary_path=sf.vocabulary_path, default_value=0)
-    assert hash(tf.constant('lake')).numpy() == 1
-    assert hash(tf.constant('johnson')).numpy() == 3
-    assert hash(tf.constant('lakemerson')).numpy() == 0
+    assert hash(tf.constant('lake')) == 1
+    assert hash(tf.constant('johnson')) == 3
+    assert hash(tf.constant('lakemerson')) == 0
 
-    hash_val = tf.strings.to_hash_bucket_fast('lakemerson', vocab_size).numpy()
+    if tf.version.VERSION < '2.0.0':
+        return
+
+    hash_val = tf.strings.to_hash_bucket_fast('lakemerson', vocab_size)
     hash = Hash(num_buckets=vocab_size)
-    assert hash(tf.constant('lakemerson')).numpy() == hash_val
+    assert hash(tf.constant('lakemerson')) == hash_val
 
-    hash_val = tf.strings.to_hash_bucket_fast('lakemerson', vocab_size-1).numpy() + 1
+    hash_val = tf.strings.to_hash_bucket_fast('lakemerson', vocab_size-1) + 1
     hash = Hash(num_buckets=vocab_size, mask_zero=True)
-    assert hash(tf.constant('lakemerson')).numpy() == hash_val
+    assert hash(tf.constant('lakemerson')) == hash_val
 
     hash = Hash(num_buckets=vocab_size, mask_zero=True)
-    assert hash(tf.constant('0')).numpy() == 0
+    assert hash(tf.constant('0')) == 0

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -20,6 +20,7 @@ except:
 def test_Hash(num_buckets, mask_zero, vocabulary_path, input_data, expected_output):
     if tf.version.VERSION < '2.0.0':
         return
+
     with CustomObjectScope({'Hash': Hash}):
         layer_test(Hash, kwargs={'num_buckets': num_buckets, 'mask_zero': mask_zero, 'vocabulary_path': vocabulary_path},
                    input_dtype=tf.string, input_data=np.array(input_data, dtype='str'),

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -1,27 +1,26 @@
+import pytest
 import tensorflow as tf
 from deepctr.layers.utils import Hash
 from deepctr.feature_column import SparseFeat
+from tests.utils import layer_test
+try:
+    from tensorflow.python.keras.utils import CustomObjectScope
+except:
+    from tensorflow.keras.utils import CustomObjectScope
 
 
-def test_hash():
-    vocab_path = "./tests/layers/vocabulary_example.csv"
-    vocab_size = 3+1
-    sf = SparseFeat('user_id', vocab_size, vocabulary_path=vocab_path)
-    hash = Hash(num_buckets=sf.vocabulary_size, vocabulary_path=sf.vocabulary_path, default_value=0)
-    assert hash(tf.constant('lake')) == 1
-    assert hash(tf.constant('johnson')) == 3
-    assert hash(tf.constant('lakemerson')) == 0
-
+@pytest.mark.parametrize(
+    'num_buckets,mask_zero,vocabulary_path,input_data,expected_output',
+    [
+        (3+1, False, None, ['lakemerson'], None),
+        (3+1, True, None, ['lakemerson'], None),
+        (3+1, False, "./tests/layers/vocabulary_example.csv", [['lake'], ['johnson'], ['lakemerson']], [[1], [3], [0]])
+    ]
+)
+def test_Hash(num_buckets, mask_zero, vocabulary_path, input_data, expected_output):
     if tf.version.VERSION < '2.0.0':
         return
-
-    hash_val = tf.strings.to_hash_bucket_fast('lakemerson', vocab_size)
-    hash = Hash(num_buckets=vocab_size)
-    assert hash(tf.constant('lakemerson')) == hash_val
-
-    hash_val = tf.strings.to_hash_bucket_fast('lakemerson', vocab_size-1) + 1
-    hash = Hash(num_buckets=vocab_size, mask_zero=True)
-    assert hash(tf.constant('lakemerson')) == hash_val
-
-    hash = Hash(num_buckets=vocab_size, mask_zero=True)
-    assert hash(tf.constant('0')) == 0
+    with CustomObjectScope({'Hash': Hash}):
+        layer_test(Hash, kwargs={'num_buckets': num_buckets, 'mask_zero': mask_zero, 'vocabulary_path': vocabulary_path},
+                   input_dtype=tf.string, input_data=tf.constant(input_data, dtype=tf.string),
+                   expected_output_dtype=tf.int64, expected_output=expected_output)

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -1,7 +1,7 @@
 import pytest
+import numpy as np
 import tensorflow as tf
 from deepctr.layers.utils import Hash
-from deepctr.feature_column import SparseFeat
 from tests.utils import layer_test
 try:
     from tensorflow.python.keras.utils import CustomObjectScope
@@ -22,5 +22,5 @@ def test_Hash(num_buckets, mask_zero, vocabulary_path, input_data, expected_outp
         return
     with CustomObjectScope({'Hash': Hash}):
         layer_test(Hash, kwargs={'num_buckets': num_buckets, 'mask_zero': mask_zero, 'vocabulary_path': vocabulary_path},
-                   input_dtype=tf.string, input_data=tf.constant(input_data, dtype=tf.string),
+                   input_dtype=tf.string, input_data=np.array(input_data, dtype='str'),
                    expected_output_dtype=tf.int64, expected_output=expected_output)

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -18,7 +18,7 @@ except:
     ]
 )
 def test_Hash(num_buckets, mask_zero, vocabulary_path, input_data, expected_output):
-    if tf.version.VERSION < '2.0.0':
+    if not hasattr(tf, 'version') or tf.version.VERSION < '2.0.0':
         return
 
     with CustomObjectScope({'Hash': Hash}):

--- a/tests/layers/vocabulary_example.csv
+++ b/tests/layers/vocabulary_example.csv
@@ -1,0 +1,3 @@
+1,lake
+2,merson
+3,johnson

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,6 +18,7 @@ SAMPLE_SIZE = 8
 VOCABULARY_SIZE = 4
 Estimator_TEST_TF1 = True
 
+
 def gen_sequence(dim, max_len, sample_size):
     return np.array([np.random.randint(0, dim, max_len) for _ in range(sample_size)]), np.random.randint(1, max_len + 1,
                                                                                                          sample_size)
@@ -44,15 +45,15 @@ def get_test_data(sample_size=1000, embedding_size=4, sparse_feature_num=1, dens
 
     for i in range(sparse_feature_num):
         if use_group:
-            group_name = str(i%3)
+            group_name = str(i % 3)
         else:
             group_name = DEFAULT_GROUP_NAME
         dim = np.random.randint(1, 10)
         feature_columns.append(
-            SparseFeat(prefix + 'sparse_feature_' + str(i), dim, embedding_size, use_hash=hash_flag, dtype=tf.int32,group_name=group_name))
+            SparseFeat(prefix + 'sparse_feature_' + str(i), dim, embedding_size, use_hash=hash_flag, dtype=tf.int32, group_name=group_name))
 
     for i in range(dense_feature_num):
-        transform_fn = lambda x: (x - 0.0)/ 1.0
+        def transform_fn(x): return (x - 0.0) / 1.0
         feature_columns.append(
             DenseFeat(
                 prefix + 'dense_feature_' + str(i),
@@ -363,6 +364,7 @@ def check_model(model, model_name, x, y, check_model_io=True):
 
     print(model_name + " test pass!")
 
+
 def get_test_data_estimator(sample_size=1000, embedding_size=4, sparse_feature_num=1, dense_feature_num=1, classification=True):
 
     x = {}
@@ -372,7 +374,7 @@ def get_test_data_estimator(sample_size=1000, embedding_size=4, sparse_feature_n
     for i in range(sparse_feature_num):
         name = 's_'+str(i)
         x[name] = np.random.randint(0, voc_size, sample_size)
-        dnn_feature_columns.append(tf.feature_column.embedding_column(tf.feature_column.categorical_column_with_identity(name,voc_size),embedding_size))
+        dnn_feature_columns.append(tf.feature_column.embedding_column(tf.feature_column.categorical_column_with_identity(name, voc_size), embedding_size))
         linear_feature_columns.append(tf.feature_column.categorical_column_with_identity(name, voc_size))
 
     for i in range(dense_feature_num):
@@ -390,8 +392,9 @@ def get_test_data_estimator(sample_size=1000, embedding_size=4, sparse_feature_n
     else:
         input_fn = tf.estimator.inputs.numpy_input_fn(x, y, shuffle=False)
 
-    return linear_feature_columns,dnn_feature_columns,input_fn
+    return linear_feature_columns, dnn_feature_columns, input_fn
 
-def check_estimator(model,input_fn):
+
+def check_estimator(model, input_fn):
     model.train(input_fn)
     model.evaluate(input_fn)


### PR DESCRIPTION
New Feature: 

Modify the `Hash` layer to support the lookup feature. 

Now there are two hash techniques  supported in the `Hash` layer:

1. Lookup Table: when setup `vocabulary_path`,  it can looks up input keys in a table  and output the corresponding values. Missed keys are always return the default value, eg. `0`.
2. Bucket Hash: when `vocabulary_path` is not set, `Hash` will hash the input keys to [0,num_buckets). Parameter `mask_zero` can set `True`, which will set the hash value `0` when the input keys are `0` or `0.0`, and other value will be hash in range [1,num_buckets).

Initializing `Hash` with `vocabulary_path` CSV file which need follow the convention：the first column as keys and second column as values which are seperated by comma. 

The following is example snippet:

    * `1,emerson`
    * `2,lake`
    * `3,palmer`

    >>> hash = Hash(
    ...   num_buckets=3+1,
    ...   vocabulary_path=filename,
    ...   default_value=0)
    >>> hash(tf.constant('lake')).numpy()
    2
    >>> hash(tf.constant('lakeemerson')).numpy()
    0
