### PR TITLE
Update sequence.py fix bugs of keras

### DIFF
--- a/deepctr/layers/sequence.py
+++ b/deepctr/layers/sequence.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     from tensorflow.python.ops.init_ops_v2 import TruncatedNormal, Constant, glorot_uniform
 
-from tensorflow.python.keras.layers import LSTM, Lambda, Layer, Dropout
+from keras.layers import LSTM, Lambda, Layer, Dropout
 
 from .core import LocalActivationUnit
 from .normalization import LayerNormalization


### PR DESCRIPTION
Hi, I fix a bug caused by the usage of keras in tensorflow 2.x. It seems that for python >=3.9, we could not install tensorflow with 1.x directly. Therefore, I think this update is important.