### PR TITLE
[codex] Update CI for modern TensorFlow support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    timeout-minutes: 180
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
@@ -47,7 +47,7 @@ jobs:
           python -m pip check
 
       - name: Test with pytest
-        timeout-minutes: 180
+        timeout-minutes: 240
         run: |
           pytest --cov=deepctr --cov-report=xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,94 +1,59 @@
-name: CI_TF2
+name: CI_TF1
 
 on:
   push:
-    path:
-      - 'deepctr/*'
-      - 'tests/*'
+    paths:
+      - 'deepctr/**'
+      - 'tests/**'
+      - 'setup.py'
+      - 'setup.cfg'
+      - '.github/workflows/**'
   pull_request:
-    path:
-      - 'deepctr/*'
-      - 'tests/*'
+    paths:
+      - 'deepctr/**'
+      - 'tests/**'
+      - 'setup.py'
+      - 'setup.cfg'
+      - '.github/workflows/**'
+  workflow_dispatch:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 180
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ 3.6,3.7,3.8, 3.9,3.10.7 ]
-        tf-version: [ 2.6.0,2.7.0,2.8.0,2.9.0,2.10.0 ]
+        include:
+          - python-version: "3.7"
+            tf-version: "1.15.5"
 
-        exclude:
-          - python-version: 3.7
-            tf-version: 1.4.0
-          - python-version: 3.7
-            tf-version: 1.15.0
-          - python-version: 3.8
-            tf-version: 1.4.0
-          - python-version: 3.8
-            tf-version: 1.14.0
-          - python-version: 3.8
-            tf-version: 1.15.0
-          - python-version: 3.6
-            tf-version: 2.7.0
-          - python-version: 3.6
-            tf-version: 2.8.0
-          - python-version: 3.6
-            tf-version: 2.9.0
-          - python-version: 3.6
-            tf-version: 2.10.0
-          - python-version: 3.9
-            tf-version: 1.4.0
-          - python-version: 3.9
-            tf-version: 1.15.0
-          - python-version: 3.9
-            tf-version: 2.2.0
-          - python-version: 3.9
-            tf-version: 2.5.0
-          - python-version: 3.9
-            tf-version: 2.6.0
-          - python-version: 3.9
-            tf-version: 2.7.0
-          - python-version: 3.10.7
-            tf-version: 1.4.0
-          - python-version: 3.10.7
-            tf-version: 1.15.0
-          - python-version: 3.10.7
-            tf-version: 2.2.0
-          - python-version: 3.10.7
-            tf-version: 2.5.0
-          - python-version: 3.10.7
-            tf-version: 2.6.0
-          - python-version: 3.10.7
-            tf-version: 2.7.0
     steps:
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Setup python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          pip3 install -q tensorflow==${{ matrix.tf-version }}
-          pip install -q protobuf==3.19.0
-          pip install -q requests
-          pip install -e .
+          python -m pip install -q --upgrade pip setuptools wheel
+          python -m pip install -q tensorflow==${{ matrix.tf-version }}
+          python -m pip install -q protobuf==3.19.0
+          python -m pip install -q pytest pytest-cov
+          python -m pip install -e .
+          python -m pip check
+
       - name: Test with pytest
         timeout-minutes: 180
         run: |
-          pip install -q pytest
-          pip install -q pytest-cov
-          pip install -q python-coveralls
           pytest --cov=deepctr --cov-report=xml
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v6
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
           flags: pytest
           name: py${{ matrix.python-version }}-tf${{ matrix.tf-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -q --upgrade pip setuptools wheel
+          python -m pip install -q "numpy<2"
           python -m pip install -q tensorflow==${{ matrix.tf-version }}
           python -m pip install -q protobuf==3.19.0
           python -m pip install -q pytest pytest-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Test with pytest
         timeout-minutes: 240
         run: |
-          pytest --cov=deepctr --cov-report=xml
+          pytest --cov=deepctr --cov-report=xml --cov-report=term-missing:skip-covered
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -q --upgrade pip setuptools wheel
+          python -m pip install -q "numpy<2"
           python -m pip install -q tensorflow==${{ matrix.tf-version }}
           if [ "${{ matrix.use-legacy-keras }}" = "1" ]; then
             python -m pip install -q tf-keras==${{ matrix.tf-version }}

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -27,16 +27,24 @@ jobs:
         include:
           - python-version: "3.10"
             tf-version: "2.10.0"
+            use-legacy-keras: "0"
           - python-version: "3.10"
             tf-version: "2.15.0"
+            use-legacy-keras: "0"
           - python-version: "3.11"
             tf-version: "2.15.0"
+            use-legacy-keras: "0"
           - python-version: "3.10"
             tf-version: "2.20.0"
+            use-legacy-keras: "1"
           - python-version: "3.11"
             tf-version: "2.20.0"
+            use-legacy-keras: "1"
           - python-version: "3.12"
             tf-version: "2.20.0"
+            use-legacy-keras: "1"
+    env:
+      TF_USE_LEGACY_KERAS: ${{ matrix.use-legacy-keras }}
 
     steps:
       - uses: actions/checkout@v5
@@ -50,6 +58,9 @@ jobs:
         run: |
           python -m pip install -q --upgrade pip setuptools wheel
           python -m pip install -q tensorflow==${{ matrix.tf-version }}
+          if [ "${{ matrix.use-legacy-keras }}" = "1" ]; then
+            python -m pip install -q tf-keras==${{ matrix.tf-version }}
+          fi
           python -m pip install -q pytest pytest-cov
           python -m pip install -e .
           python -m pip check

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -1,96 +1,68 @@
-name: CI_TF1
+name: CI_TF2
 
 on:
   push:
-    path:
-      - 'deepctr/*'
-      - 'tests/*'
+    paths:
+      - 'deepctr/**'
+      - 'tests/**'
+      - 'setup.py'
+      - 'setup.cfg'
+      - '.github/workflows/**'
   pull_request:
-    path:
-      - 'deepctr/*'
-      - 'tests/*'
+    paths:
+      - 'deepctr/**'
+      - 'tests/**'
+      - 'setup.py'
+      - 'setup.cfg'
+      - '.github/workflows/**'
+  workflow_dispatch:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ 3.6,3.7 ]
-        tf-version: [ 1.15.0 ]
+        include:
+          - python-version: "3.10"
+            tf-version: "2.10.0"
+          - python-version: "3.10"
+            tf-version: "2.15.0"
+          - python-version: "3.11"
+            tf-version: "2.15.0"
+          - python-version: "3.10"
+            tf-version: "2.20.0"
+          - python-version: "3.11"
+            tf-version: "2.20.0"
+          - python-version: "3.12"
+            tf-version: "2.20.0"
 
-        exclude:
-          - python-version: 3.7
-            tf-version: 1.4.0
-          - python-version: 3.7
-            tf-version: 1.12.0
-          - python-version: 3.7
-            tf-version: 1.15.0
-          - python-version: 3.8
-            tf-version: 1.4.0
-          - python-version: 3.8
-            tf-version: 1.14.0
-          - python-version: 3.8
-            tf-version: 1.15.0
-          - python-version: 3.6
-            tf-version: 2.7.0
-          - python-version: 3.6
-            tf-version: 2.8.0
-          - python-version: 3.6
-            tf-version: 2.9.0
-          - python-version: 3.6
-            tf-version: 2.10.0
-          - python-version: 3.9
-            tf-version: 1.4.0
-          - python-version: 3.9
-            tf-version: 1.15.0
-          - python-version: 3.9
-            tf-version: 2.2.0
-          - python-version: 3.9
-            tf-version: 2.5.0
-          - python-version: 3.9
-            tf-version: 2.6.0
-          - python-version: 3.9
-            tf-version: 2.7.0
-          - python-version: 3.10.7
-            tf-version: 1.4.0
-          - python-version: 3.10.7
-            tf-version: 1.15.0
-          - python-version: 3.10.7
-            tf-version: 2.2.0
-          - python-version: 3.10.7
-            tf-version: 2.5.0
-          - python-version: 3.10.7
-            tf-version: 2.6.0
-          - python-version: 3.10.7
-            tf-version: 2.7.0
     steps:
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Setup python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          pip3 install -q tensorflow==${{ matrix.tf-version }}
-          pip install -q protobuf==3.19.0
-          pip install -q requests
-          pip install -e .
+          python -m pip install -q --upgrade pip setuptools wheel
+          python -m pip install -q tensorflow==${{ matrix.tf-version }}
+          python -m pip install -q pytest pytest-cov
+          python -m pip install -e .
+          python -m pip check
+
       - name: Test with pytest
-        timeout-minutes: 360
+        timeout-minutes: 180
         run: |
-          pip install -q pytest
-          pip install -q pytest-cov
-          pip install -q python-coveralls
           pytest --cov=deepctr --cov-report=xml
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v6
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
           flags: pytest
           name: py${{ matrix.python-version }}-tf${{ matrix.tf-version }}

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Test with pytest
         timeout-minutes: 180
         run: |
-          pytest --cov=deepctr --cov-report=xml
+          pytest --cov=deepctr --cov-report=xml --cov-report=term-missing:skip-covered
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 
 [![Documentation Status](https://readthedocs.org/projects/deepctr-doc/badge/?version=latest)](https://deepctr-doc.readthedocs.io/)
-![CI status](https://github.com/shenweichen/deepctr/workflows/CI/badge.svg)
+[![CI_TF1](https://github.com/shenweichen/DeepCTR/actions/workflows/ci.yml/badge.svg)](https://github.com/shenweichen/DeepCTR/actions/workflows/ci.yml)
+[![CI_TF2](https://github.com/shenweichen/DeepCTR/actions/workflows/ci2.yml/badge.svg)](https://github.com/shenweichen/DeepCTR/actions/workflows/ci2.yml)
 [![codecov](https://codecov.io/gh/shenweichen/DeepCTR/branch/master/graph/badge.svg)](https://codecov.io/gh/shenweichen/DeepCTR)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d4099734dc0e4bab91d332ead8c0bdd0)](https://www.codacy.com/gh/shenweichen/DeepCTR?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=shenweichen/DeepCTR&amp;utm_campaign=Badge_Grade)
 [![Disscussion](https://img.shields.io/badge/chat-wechat-brightgreen?style=flat)](./README.md#DisscussionGroup)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DeepCTR
 
 [![Python Versions](https://img.shields.io/pypi/pyversions/deepctr.svg)](https://pypi.org/project/deepctr)
-[![TensorFlow Versions](https://img.shields.io/badge/TensorFlow-1.4+/2.0+-blue.svg)](https://pypi.org/project/deepctr)
+[![TensorFlow Versions](https://img.shields.io/badge/TensorFlow-1.15/2.0+-blue.svg)](https://pypi.org/project/deepctr)
 [![Downloads](https://pepy.tech/badge/deepctr)](https://pepy.tech/project/deepctr)
 [![PyPI Version](https://img.shields.io/pypi/v/deepctr.svg)](https://pypi.org/project/deepctr)
 [![GitHub Issues](https://img.shields.io/github/issues/shenweichen/deepctr.svg
@@ -92,9 +92,9 @@ If you find this code useful in your research, please cite it using the followin
 - [Github Discussions](https://github.com/shenweichen/DeepCTR/discussions)
 - Wechat Discussions
 
-|公众号：浅梦学习笔记|微信：deepctrbot|学习小组 [加入](https://t.zsxq.com/026UJEuzv) [主题集合](https://mp.weixin.qq.com/mp/appmsgalbum?__biz=MjM5MzY4NzE3MA==&action=getalbum&album_id=1361647041096843265&scene=126#wechat_redirect)|
-|:--:|:--:|:--:|
-| [![公众号](./docs/pics/code.png)](https://github.com/shenweichen/AlgoNotes)| [![微信](./docs/pics/deepctrbot.png)](https://github.com/shenweichen/AlgoNotes)|[![学习小组](./docs/pics/planet_github.png)](https://t.zsxq.com/026UJEuzv)|
+|公众号：浅梦学习笔记|微信：deepctrbot|
+|:--:|:--:|
+| [![公众号](./docs/pics/code.png)](https://github.com/shenweichen/AlgoNotes)| [![微信](./docs/pics/deepctrbot.png)](https://github.com/shenweichen/AlgoNotes)|
 
 ## Main contributors([welcome to join us!](./CONTRIBUTING.md))
 

--- a/deepctr/__init__.py
+++ b/deepctr/__init__.py
@@ -1,4 +1,4 @@
 from .utils import check_version
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 check_version(__version__)

--- a/deepctr/estimator/models/fibinet.py
+++ b/deepctr/estimator/models/fibinet.py
@@ -8,7 +8,7 @@ Reference:
 """
 
 import tensorflow as tf
-from tensorflow.python.keras.layers import Dense, Flatten
+from tensorflow.keras.layers import Dense, Flatten
 
 from ..feature_column import get_linear_logit, input_from_feature_columns
 from ..utils import deepctr_model_fn, DNN_SCOPE_NAME, variable_scope

--- a/deepctr/estimator/models/wdl.py
+++ b/deepctr/estimator/models/wdl.py
@@ -8,7 +8,7 @@ Reference:
 """
 
 import tensorflow as tf
-from tensorflow.python.keras.layers import Dense
+from tensorflow.keras.layers import Dense
 
 from ..feature_column import get_linear_logit, input_from_feature_columns
 from ..utils import deepctr_model_fn, DNN_SCOPE_NAME, variable_scope

--- a/deepctr/feature_column.py
+++ b/deepctr/feature_column.py
@@ -3,8 +3,8 @@ from collections import namedtuple, OrderedDict
 from copy import copy
 from itertools import chain
 
-from tensorflow.python.keras.initializers import RandomNormal, Zeros
-from tensorflow.python.keras.layers import Input, Lambda
+from tensorflow.keras.initializers import RandomNormal, Zeros
+from tensorflow.keras.layers import Input, Lambda
 
 from .inputs import create_embedding_matrix, embedding_lookup, get_dense_input, varlen_embedding_lookup, \
     get_varlen_pooling_list, mergeDict

--- a/deepctr/inputs.py
+++ b/deepctr/inputs.py
@@ -9,8 +9,8 @@ Author:
 from collections import defaultdict
 from itertools import chain
 
-from tensorflow.python.keras.layers import Embedding, Lambda
-from tensorflow.python.keras.regularizers import l2
+from tensorflow.keras.layers import Embedding, Lambda
+from tensorflow.keras.regularizers import l2
 
 from .layers.sequence import SequencePoolingLayer, WeightedSequenceLayer
 from .layers.utils import Hash

--- a/deepctr/layers/activation.py
+++ b/deepctr/layers/activation.py
@@ -12,10 +12,10 @@ try:
     from tensorflow.python.ops.init_ops import Zeros
 except ImportError:
     from tensorflow.python.ops.init_ops_v2 import Zeros
-from tensorflow.python.keras.layers import Layer, Activation
+from tensorflow.keras.layers import Layer, Activation
 
 try:
-    from tensorflow.python.keras.layers import BatchNormalization
+    from tensorflow.keras.layers import BatchNormalization
 except ImportError:
     BatchNormalization = tf.keras.layers.BatchNormalization
 

--- a/deepctr/layers/core.py
+++ b/deepctr/layers/core.py
@@ -7,20 +7,20 @@ Author:
 """
 
 import tensorflow as tf
-from tensorflow.python.keras import backend as K
+from tensorflow.keras import backend as K
 
 try:
     from tensorflow.python.ops.init_ops_v2 import Zeros, Ones, glorot_normal
 except ImportError:
     from tensorflow.python.ops.init_ops import Zeros, Ones, glorot_normal_initializer as glorot_normal
 
-from tensorflow.python.keras.layers import Layer, Dropout
+from tensorflow.keras.layers import Layer, Dropout
 
 try:
-    from tensorflow.python.keras.layers import BatchNormalization
+    from tensorflow.keras.layers import BatchNormalization
 except ImportError:
     BatchNormalization = tf.keras.layers.BatchNormalization
-from tensorflow.python.keras.regularizers import l2
+from tensorflow.keras.regularizers import l2
 
 from .activation import activation_layer
 

--- a/deepctr/layers/interaction.py
+++ b/deepctr/layers/interaction.py
@@ -11,8 +11,8 @@ Authors:
 import itertools
 
 import tensorflow as tf
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.backend import batch_dot
+from tensorflow.keras import backend as K
+from tensorflow.keras.backend import batch_dot
 
 try:
     from tensorflow.python.ops.init_ops import Zeros, Ones, Constant, TruncatedNormal, \
@@ -21,8 +21,8 @@ try:
 except ImportError:
     from tensorflow.python.ops.init_ops_v2 import Zeros, Ones, Constant, TruncatedNormal, glorot_normal, glorot_uniform
 
-from tensorflow.python.keras.layers import Layer, MaxPooling2D, Conv2D, Dropout, Lambda, Dense, Flatten
-from tensorflow.python.keras.regularizers import l2
+from tensorflow.keras.layers import Layer, MaxPooling2D, Conv2D, Dropout, Lambda, Dense, Flatten
+from tensorflow.keras.regularizers import l2
 from tensorflow.python.layers import utils
 
 from .activation import activation_layer

--- a/deepctr/layers/interaction.py
+++ b/deepctr/layers/interaction.py
@@ -30,6 +30,12 @@ from .utils import concat_func, reduce_sum, softmax, reduce_mean
 from .core import DNN
 
 
+def _shape_to_list(shape):
+    if hasattr(shape, "as_list"):
+        return shape.as_list()
+    return [dim.value if hasattr(dim, "value") else dim for dim in shape]
+
+
 class AFMLayer(Layer):
     """Attentonal Factorization Machine models pairwise (order-2) feature
     interactions without linear term and bias.
@@ -72,7 +78,7 @@ class AFMLayer(Layer):
                              'on a list of at least 2 inputs')
 
         shape_set = set()
-        reduced_input_shape = [shape.as_list() for shape in input_shape]
+        reduced_input_shape = [_shape_to_list(shape) for shape in input_shape]
         for i in range(len(input_shape)):
             shape_set.add(tuple(reduced_input_shape[i]))
 
@@ -628,7 +634,7 @@ class InnerProductLayer(Layer):
             raise ValueError('A `InnerProductLayer` layer should be called '
                              'on a list of at least 2 inputs')
 
-        reduced_inputs_shapes = [shape.as_list() for shape in input_shape]
+        reduced_inputs_shapes = [_shape_to_list(shape) for shape in input_shape]
         shape_set = set()
 
         for i in range(len(input_shape)):
@@ -816,7 +822,7 @@ class OutterProductLayer(Layer):
             raise ValueError('A `OutterProductLayer` layer should be called '
                              'on a list of at least 2 inputs')
 
-        reduced_inputs_shapes = [shape.as_list() for shape in input_shape]
+        reduced_inputs_shapes = [_shape_to_list(shape) for shape in input_shape]
         shape_set = set()
 
         for i in range(len(input_shape)):
@@ -961,7 +967,7 @@ class FGCNNLayer(Layer):
         self.conv_layers = []
         self.pooling_layers = []
         self.dense_layers = []
-        pooling_shape = input_shape.as_list() + [1, ]
+        pooling_shape = _shape_to_list(input_shape) + [1, ]
         embedding_size = int(input_shape[-1])
         for i in range(1, len(self.filters) + 1):
             filters = self.filters[i - 1]

--- a/deepctr/layers/normalization.py
+++ b/deepctr/layers/normalization.py
@@ -6,8 +6,8 @@ Author:
 
 """
 
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.layers import Layer
+from tensorflow.keras import backend as K
+from tensorflow.keras.layers import Layer
 
 try:
     from tensorflow.python.ops.init_ops import Zeros, Ones

--- a/deepctr/layers/sequence.py
+++ b/deepctr/layers/sequence.py
@@ -8,14 +8,14 @@ Author:
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.keras import backend as K
+from tensorflow.keras import backend as K
 
 try:
     from tensorflow.python.ops.init_ops import TruncatedNormal, Constant, glorot_uniform_initializer as glorot_uniform
 except ImportError:
     from tensorflow.python.ops.init_ops_v2 import TruncatedNormal, Constant, glorot_uniform
 
-from tensorflow.python.keras.layers import LSTM, Lambda, Layer, Dropout
+from tensorflow.keras.layers import LSTM, Lambda, Layer, Dropout
 
 from .core import LocalActivationUnit
 from .normalization import LayerNormalization

--- a/deepctr/layers/sequence.py
+++ b/deepctr/layers/sequence.py
@@ -28,6 +28,16 @@ from ..contrib.utils import QAAttGRUCell, VecAttGRUCell
 from .utils import reduce_sum, reduce_max, div, softmax, reduce_mean
 
 
+def _dim_value(dim):
+    return dim.value if hasattr(dim, "value") else dim
+
+
+def _shape_to_list(shape):
+    if hasattr(shape, "as_list"):
+        return shape.as_list()
+    return [_dim_value(dim) for dim in shape]
+
+
 class SequencePoolingLayer(Layer):
     """The SequencePoolingLayer is used to apply pooling operation(sum,mean,max) on variable-length sequence feature/multi-value feature.
 
@@ -652,7 +662,7 @@ class PositionEncoding(Layer):
 
     def build(self, input_shape):
         # Create a trainable weight variable for this layer.
-        _, T, num_units = input_shape.as_list()  # inputs.get_shape().as_list()
+        _, T, num_units = _shape_to_list(input_shape)  # inputs.get_shape().as_list()
         # First part of the PE function: sin and cos argument
         position_enc = np.array([
             [pos / np.power(10000, 2. * (i // 2) / num_units) for i in range(num_units)]
@@ -703,15 +713,11 @@ class BiasEncoding(Layer):
         # Create a trainable weight variable for this layer.
 
         if self.sess_max_count == 1:
-            embed_size = input_shape[2].value
-            seq_len_max = input_shape[1].value
+            embed_size = _dim_value(input_shape[2])
+            seq_len_max = _dim_value(input_shape[1])
         else:
-            try:
-                embed_size = input_shape[0][2].value
-                seq_len_max = input_shape[0][1].value
-            except AttributeError:
-                embed_size = input_shape[0][2]
-                seq_len_max = input_shape[0][1]
+            embed_size = _dim_value(input_shape[0][2])
+            seq_len_max = _dim_value(input_shape[0][1])
 
         self.sess_bias_embedding = self.add_weight('sess_bias_embedding', shape=(self.sess_max_count, 1, 1),
                                                    initializer=TruncatedNormal(
@@ -763,7 +769,7 @@ class DynamicGRU(Layer):
         # Create a trainable weight variable for this layer.
         input_seq_shape = input_shape[0]
         if self.num_units is None:
-            self.num_units = input_seq_shape.as_list()[-1]
+            self.num_units = _shape_to_list(input_seq_shape)[-1]
         if self.gru_type == "AGRU":
             self.gru_cell = QAAttGRUCell(self.num_units)
         elif self.gru_type == "AUGRU":

--- a/deepctr/layers/utils.py
+++ b/deepctr/layers/utils.py
@@ -6,8 +6,8 @@ Author:
 
 """
 import tensorflow as tf
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.layers import Flatten, Layer, Add
+from tensorflow.keras import backend as K
+from tensorflow.keras.layers import Flatten, Layer, Add
 from tensorflow.python.ops.lookup_ops import TextFileInitializer
 
 try:
@@ -15,7 +15,7 @@ try:
 except ImportError:
     from tensorflow.python.ops.init_ops_v2 import Zeros, glorot_normal
 
-from tensorflow.python.keras.regularizers import l2
+from tensorflow.keras.regularizers import l2
 
 try:
     from tensorflow.python.ops.lookup_ops import StaticHashTable

--- a/deepctr/models/afm.py
+++ b/deepctr/models/afm.py
@@ -9,7 +9,7 @@ Reference:
     (https://arxiv.org/abs/1708.04617)
 
 """
-from tensorflow.python.keras.models import Model
+from tensorflow.keras.models import Model
 from ..feature_column import build_input_features, get_linear_logit, DEFAULT_GROUP_NAME, input_from_feature_columns
 from ..layers.core import PredictionLayer
 from ..layers.interaction import AFMLayer, FM

--- a/deepctr/models/autoint.py
+++ b/deepctr/models/autoint.py
@@ -9,8 +9,8 @@ Reference:
 
 """
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Flatten, Concatenate, Dense
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Flatten, Concatenate, Dense
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/ccpm.py
+++ b/deepctr/models/ccpm.py
@@ -10,8 +10,8 @@ Reference:
 
 """
 import tensorflow as tf
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Flatten, Conv2D, Lambda
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Flatten, Conv2D, Lambda
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import DNN, PredictionLayer

--- a/deepctr/models/dcn.py
+++ b/deepctr/models/dcn.py
@@ -10,8 +10,8 @@ Reference:
 
     [2] Wang R, Shivanna R, Cheng D Z, et al. DCN-M: Improved Deep & Cross Network for Feature Cross Learning in Web-scale Learning to Rank Systems[J]. 2020. (https://arxiv.org/abs/2008.13535)
 """
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Concatenate
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Concatenate
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/dcnmix.py
+++ b/deepctr/models/dcnmix.py
@@ -10,8 +10,8 @@ Reference:
 
     [2] Wang R, Shivanna R, Cheng D Z, et al. DCN V2: Improved Deep & Cross Network and Practical Lessons for Web-scale Learning to Rank Systems[J]. 2020. (https://arxiv.org/abs/2008.13535)
 """
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Concatenate
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Concatenate
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/deepfefm.py
+++ b/deepctr/models/deepfefm.py
@@ -13,8 +13,8 @@ Reference:
 
 from itertools import chain
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Lambda
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Lambda
 
 from ..feature_column import input_from_feature_columns, get_linear_logit, build_input_features, DEFAULT_GROUP_NAME
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/deepfm.py
+++ b/deepctr/models/deepfm.py
@@ -10,8 +10,8 @@ Reference:
 
 from itertools import chain
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
 
 from ..feature_column import build_input_features, get_linear_logit, DEFAULT_GROUP_NAME, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/difm.py
+++ b/deepctr/models/difm.py
@@ -7,8 +7,8 @@ Reference:
     //IJCAI. 2020: 3139-3145.(https://www.ijcai.org/Proceedings/2020/0434.pdf)
 """
 import tensorflow as tf
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Lambda, Flatten
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Lambda, Flatten
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns, SparseFeat, \
     VarLenSparseFeat

--- a/deepctr/models/edcn.py
+++ b/deepctr/models/edcn.py
@@ -6,8 +6,8 @@ Author:
 Reference:
     [1] Chen, B., Wang, Y., Liu, et al. Enhancing Explicit and Implicit Feature Interactions via Information Sharing for Parallel Deep CTR Models. CIKM, 2021, October (https://dlp-kdd.github.io/assets/pdf/DLP-KDD_2021_paper_12.pdf)
 """
-from tensorflow.python.keras.layers import Dense, Reshape, Concatenate
-from tensorflow.python.keras.models import Model
+from tensorflow.keras.layers import Dense, Reshape, Concatenate
+from tensorflow.keras.models import Model
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN, RegulationModule

--- a/deepctr/models/fgcnn.py
+++ b/deepctr/models/fgcnn.py
@@ -10,8 +10,8 @@ Reference:
 
 """
 import tensorflow as tf
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Lambda, Flatten, Concatenate
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Lambda, Flatten, Concatenate
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/fibinet.py
+++ b/deepctr/models/fibinet.py
@@ -7,8 +7,8 @@ Reference:
     [1] Huang T, Zhang Z, Zhang J. FiBiNET: Combining Feature Importance and Bilinear feature Interaction for Click-Through Rate Prediction[J]. arXiv preprint arXiv:1905.09433, 2019.
 """
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Flatten
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Flatten
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/flen.py
+++ b/deepctr/models/flen.py
@@ -10,8 +10,8 @@ Reference:
 
 from itertools import chain
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/fnn.py
+++ b/deepctr/models/fnn.py
@@ -6,8 +6,8 @@ Author:
 Reference:
     [1] Zhang W, Du T, Wang J. Deep learning over multi-field categorical data[C]//European conference on information retrieval. Springer, Cham, 2016: 45-57.(https://arxiv.org/pdf/1601.02376.pdf)
 """
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/fwfm.py
+++ b/deepctr/models/fwfm.py
@@ -11,8 +11,8 @@ Reference:
 
 from itertools import chain
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
 
 from ..feature_column import build_input_features, get_linear_logit, DEFAULT_GROUP_NAME, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/ifm.py
+++ b/deepctr/models/ifm.py
@@ -8,8 +8,8 @@ Reference:
 """
 
 import tensorflow as tf
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Lambda
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Lambda
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns, SparseFeat, \
     VarLenSparseFeat

--- a/deepctr/models/mlr.py
+++ b/deepctr/models/mlr.py
@@ -6,8 +6,8 @@ Author:
 Reference:
     [1] Gai K, Zhu X, Li H, et al. Learning Piece-wise Linear Models from Large Scale Data for Ad Click Prediction[J]. arXiv preprint arXiv:1704.05194, 2017.(https://arxiv.org/abs/1704.05194)
 """
-from tensorflow.python.keras.layers import Activation, dot
-from tensorflow.python.keras.models import Model
+from tensorflow.keras.layers import Activation, dot
+from tensorflow.keras.models import Model
 
 from ..feature_column import build_input_features, get_linear_logit
 from ..layers.core import PredictionLayer

--- a/deepctr/models/multitask/esmm.py
+++ b/deepctr/models/multitask/esmm.py
@@ -8,8 +8,8 @@ Reference:
     [1] Ma X, Zhao L, Huang G, et al. Entire space multi-task model: An effective approach for estimating post-click conversion rate[C]//The 41st International ACM SIGIR Conference on Research & Development in Information Retrieval. 2018.(https://arxiv.org/abs/1804.07931)
 """
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Multiply
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Multiply
 
 from ...feature_column import build_input_features, input_from_feature_columns
 from ...layers.core import PredictionLayer, DNN

--- a/deepctr/models/multitask/mmoe.py
+++ b/deepctr/models/multitask/mmoe.py
@@ -9,8 +9,8 @@ Reference:
 """
 
 import tensorflow as tf
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Lambda
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Lambda
 
 from ...feature_column import build_input_features, input_from_feature_columns
 from ...layers.core import PredictionLayer, DNN

--- a/deepctr/models/multitask/ple.py
+++ b/deepctr/models/multitask/ple.py
@@ -9,8 +9,8 @@ Reference:
 """
 
 import tensorflow as tf
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Lambda
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Lambda
 
 from ...feature_column import build_input_features, input_from_feature_columns
 from ...layers.core import PredictionLayer, DNN

--- a/deepctr/models/multitask/sharedbottom.py
+++ b/deepctr/models/multitask/sharedbottom.py
@@ -8,8 +8,8 @@ Reference:
     [1] Ruder S. An overview of multi-task learning in deep neural networks[J]. arXiv preprint arXiv:1706.05098, 2017.(https://arxiv.org/pdf/1706.05098.pdf)
 """
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
 
 from ...feature_column import build_input_features, input_from_feature_columns
 from ...layers.core import PredictionLayer, DNN

--- a/deepctr/models/nfm.py
+++ b/deepctr/models/nfm.py
@@ -6,8 +6,8 @@ Author:
 Reference:
     [1] He X, Chua T S. Neural factorization machines for sparse predictive analytics[C]//Proceedings of the 40th International ACM SIGIR conference on Research and Development in Information Retrieval. ACM, 2017: 355-364. (https://arxiv.org/abs/1708.05027)
 """
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Dropout
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Dropout
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/onn.py
+++ b/deepctr/models/onn.py
@@ -11,16 +11,16 @@ Reference:
 
 import itertools
 
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.layers import (Dense, Embedding, Lambda,
+from tensorflow.keras import backend as K
+from tensorflow.keras.layers import (Dense, Embedding, Lambda,
                                             multiply, Flatten)
 try:
-    from tensorflow.python.keras.layers import BatchNormalization
+    from tensorflow.keras.layers import BatchNormalization
 except ImportError:
     import tensorflow as tf
     BatchNormalization = tf.keras.layers.BatchNormalization
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.regularizers import l2
+from tensorflow.keras.models import Model
+from tensorflow.keras.regularizers import l2
 
 from ..feature_column import SparseFeat, VarLenSparseFeat, build_input_features, get_linear_logit
 from ..inputs import get_dense_input

--- a/deepctr/models/pnn.py
+++ b/deepctr/models/pnn.py
@@ -7,8 +7,8 @@ Reference:
     [1] Qu Y, Cai H, Ren K, et al. Product-based neural networks for user response prediction[C]//Data Mining (ICDM), 2016 IEEE 16th International Conference on. IEEE, 2016: 1149-1154.(https://arxiv.org/pdf/1611.00144.pdf)
 """
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense, Reshape, Flatten
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Reshape, Flatten
 
 from ..feature_column import build_input_features, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/sequence/bst.py
+++ b/deepctr/models/sequence/bst.py
@@ -7,8 +7,8 @@ Reference:
     Qiwei Chen, Huan Zhao, Wei Li, Pipei Huang, and Wenwu Ou. 2019. Behavior sequence transformer for e-commerce recommendation in Alibaba. In Proceedings of the 1st International Workshop on Deep Learning Practice for High-Dimensional Sparse Data (DLP-KDD '19). Association for Computing Machinery, New York, NY, USA, Article 12, 1–4. DOI:https://doi.org/10.1145/3326937.3341261
 """
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import (Dense, Flatten)
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import (Dense, Flatten)
 
 from ...feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, build_input_features
 from ...inputs import get_varlen_pooling_list, create_embedding_matrix, embedding_lookup, varlen_embedding_lookup, \

--- a/deepctr/models/sequence/dien.py
+++ b/deepctr/models/sequence/dien.py
@@ -8,8 +8,8 @@ Reference:
 """
 
 import tensorflow as tf
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import (Concatenate, Dense, Permute, multiply, Flatten)
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import (Concatenate, Dense, Permute, multiply, Flatten)
 
 from ...feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, build_input_features
 from ...inputs import get_varlen_pooling_list, create_embedding_matrix, embedding_lookup, varlen_embedding_lookup, \

--- a/deepctr/models/sequence/din.py
+++ b/deepctr/models/sequence/din.py
@@ -6,8 +6,8 @@ Author:
 Reference:
     [1] Zhou G, Zhu X, Song C, et al. Deep interest network for click-through rate prediction[C]//Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. ACM, 2018: 1059-1068. (https://arxiv.org/pdf/1706.06978.pdf)
 """
-from tensorflow.python.keras.layers import Dense, Flatten
-from tensorflow.python.keras.models import Model
+from tensorflow.keras.layers import Dense, Flatten
+from tensorflow.keras.models import Model
 
 from ...feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, build_input_features
 from ...inputs import create_embedding_matrix, embedding_lookup, get_dense_input, varlen_embedding_lookup, \

--- a/deepctr/models/sequence/dsin.py
+++ b/deepctr/models/sequence/dsin.py
@@ -10,10 +10,10 @@ Reference:
 
 from collections import OrderedDict
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import (Concatenate, Dense, Embedding,
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import (Concatenate, Dense, Embedding,
                                             Flatten, Input)
-from tensorflow.python.keras.regularizers import l2
+from tensorflow.keras.regularizers import l2
 
 from ...feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, build_input_features
 from ...inputs import (get_embedding_vec_list, get_inputs_list, embedding_lookup, get_dense_input)

--- a/deepctr/models/wdl.py
+++ b/deepctr/models/wdl.py
@@ -7,8 +7,8 @@ Reference:
     [1] Cheng H T, Koc L, Harmsen J, et al. Wide & deep learning for recommender systems[C]//Proceedings of the 1st Workshop on Deep Learning for Recommender Systems. ACM, 2016: 7-10.(https://arxiv.org/pdf/1606.07792.pdf)
 """
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/deepctr/models/xdeepfm.py
+++ b/deepctr/models/xdeepfm.py
@@ -6,8 +6,8 @@ Author:
 Reference:
     [1] Lian J, Zhou X, Zhang F, et al. xDeepFM: Combining Explicit and Implicit Feature Interactions for Recommender Systems[J]. arXiv preprint arXiv:1803.05170, 2018.(https://arxiv.org/pdf/1803.05170.pdf)
 """
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras.layers import Dense
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
 
 from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
 from ..layers.core import PredictionLayer, DNN

--- a/docs/source/History.md
+++ b/docs/source/History.md
@@ -1,4 +1,5 @@
 # History
+- 04/16/2026 : [v0.9.4](https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.4) released.Support higher tensorflow version.
 - 11/10/2022 : [v0.9.3](https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.3) released.Add [EDCN](./Features.html#edcn-enhancing-explicit-and-implicit-feature-interactions-dcn).
 - 10/15/2022 : [v0.9.2](https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.2) released.Support python `3.9`,`3.10`.
 - 06/11/2022 : [v0.9.1](https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.1) released.Improve compatibility with tensorflow `2.x`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = 'Weichen Shen'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.9.3'
+release = '0.9.4'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,20 +42,20 @@ You can read the latest code and related projects
 
 News
 -----
+04/16/2026 : Support higher tensorflow version . `Changelog <https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.4>`_
+
 11/10/2022 : Add `EDCN` . `Changelog <https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.3>`_
 
 10/15/2022 : Support python `3.9` , `3.10` . `Changelog <https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.2>`_
-
-06/11/2022 : Improve compatibility with tensorflow `2.x`. `Changelog <https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.1>`_
 
 DisscussionGroup
 -----------------------
 
   公众号：**浅梦学习笔记**  wechat ID: **deepctrbot**
 
-  `Discussions <https://github.com/shenweichen/DeepCTR/discussions>`_ `学习小组主题集合 <https://mp.weixin.qq.com/mp/appmsgalbum?__biz=MjM5MzY4NzE3MA==&action=getalbum&album_id=1361647041096843265&scene=126#wechat_redirect>`_
+  `Discussions <https://github.com/shenweichen/DeepCTR/discussions>`_ 
 
-.. image:: ../pics/code2.jpg
+.. image:: ../pics/code.jpg
 
 .. toctree::
    :maxdepth: 2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ REQUIRED_PACKAGES = [
 
 setuptools.setup(
     name="deepctr",
-    version="0.9.3",
+    version="0.9.4",
     author="Weichen Shen",
     author_email="weichenswc@163.com",
     description="Easy-to-use,Modular and Extendible package of deep learning based CTR(Click Through Rate) prediction models with tensorflow 1.x and 2.x .",
@@ -23,33 +23,29 @@ setuptools.setup(
     download_url='https://github.com/shenweichen/deepctr/tags',
     packages=setuptools.find_packages(
         exclude=["tests", "tests.models", "tests.layers"]),
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",  # '>=3.4',  # 3.4.6
+    python_requires=">=3.7",
     install_requires=REQUIRED_PACKAGES,
     extras_require={
-        "cpu": ["tensorflow>=1.4.0,!=1.7.*,!=1.8.*"],
-        "gpu": ["tensorflow-gpu>=1.4.0,!=1.7.*,!=1.8.*"],
     },
     entry_points={
     },
-    classifiers=(
+    classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         'Intended Audience :: Developers',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Software Development',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ),
+    ],
     license="Apache-2.0",
     keywords=['ctr', 'click through rate',
               'deep learning', 'tensorflow', 'tensor', 'keras'],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 REQUIRED_PACKAGES = [
     'requests',
-    'h5py==3.7.0; python_version>="3.9"',
+    'h5py>=3.7.0; python_version>="3.9"',
     'h5py==2.10.0; python_version<"3.9"'
 ]
 

--- a/tests/layers/activations_test.py
+++ b/tests/layers/activations_test.py
@@ -1,9 +1,9 @@
 from deepctr.layers import activation
 
 try:
-    from tensorflow.python.keras.utils.generic_utils import CustomObjectScope
+    from tensorflow.keras.utils.generic_utils import CustomObjectScope
 except ImportError:
-    from tensorflow.python.keras.utils import CustomObjectScope
+    from tensorflow.keras.utils import CustomObjectScope
 from tests.utils import layer_test
 
 

--- a/tests/layers/core_test.py
+++ b/tests/layers/core_test.py
@@ -1,11 +1,11 @@
 import pytest
 import tensorflow as tf
-from tensorflow.python.keras.layers import PReLU
+from tensorflow.keras.layers import PReLU
 
 try:
-    from tensorflow.python.keras.utils.generic_utils import CustomObjectScope
+    from tensorflow.keras.utils.generic_utils import CustomObjectScope
 except ImportError:
-    from tensorflow.python.keras.utils import CustomObjectScope
+    from tensorflow.keras.utils import CustomObjectScope
 from deepctr import layers
 from deepctr.layers import Dice
 from tests.layers.interaction_test import BATCH_SIZE, EMBEDDING_SIZE, SEQ_LENGTH

--- a/tests/layers/interaction_test.py
+++ b/tests/layers/interaction_test.py
@@ -1,9 +1,9 @@
 import pytest
 
 try:
-    from tensorflow.python.keras.utils.generic_utils import CustomObjectScope
+    from tensorflow.keras.utils.generic_utils import CustomObjectScope
 except ImportError:
-    from tensorflow.python.keras.utils import CustomObjectScope
+    from tensorflow.keras.utils import CustomObjectScope
 from deepctr import layers
 
 from tests.utils import layer_test

--- a/tests/layers/normalization_test.py
+++ b/tests/layers/normalization_test.py
@@ -1,9 +1,9 @@
 import pytest
 
 try:
-    from tensorflow.python.keras.utils.generic_utils import CustomObjectScope
+    from tensorflow.keras.utils.generic_utils import CustomObjectScope
 except ImportError:
-    from tensorflow.python.keras.utils import CustomObjectScope
+    from tensorflow.keras.utils import CustomObjectScope
 from deepctr import layers
 from tests.layers.interaction_test import BATCH_SIZE, FIELD_SIZE, EMBEDDING_SIZE
 from tests.utils import layer_test

--- a/tests/layers/sequence_test.py
+++ b/tests/layers/sequence_test.py
@@ -2,9 +2,9 @@ import pytest
 from packaging import version
 
 try:
-    from tensorflow.python.keras.utils.generic_utils import CustomObjectScope
+    from tensorflow.keras.utils.generic_utils import CustomObjectScope
 except ImportError:
-    from tensorflow.python.keras.utils import CustomObjectScope
+    from tensorflow.keras.utils import CustomObjectScope
 import tensorflow as tf
 from deepctr.layers import sequence
 
@@ -12,7 +12,7 @@ from tests.utils import layer_test
 try:
     tf.keras.backend.set_learning_phase(True)
 except ImportError:
-    from tensorflow.python.keras.backend import set_learning_phase
+    from tensorflow.keras.backend import set_learning_phase
     set_learning_phase(True)
 BATCH_SIZE = 4
 EMBEDDING_SIZE = 8

--- a/tests/layers/utils_test.py
+++ b/tests/layers/utils_test.py
@@ -7,9 +7,9 @@ from tests.layers.interaction_test import BATCH_SIZE, EMBEDDING_SIZE
 from tests.utils import layer_test
 
 try:
-    from tensorflow.python.keras.utils.generic_utils import CustomObjectScope
+    from tensorflow.keras.utils.generic_utils import CustomObjectScope
 except ImportError:
-    from tensorflow.python.keras.utils import CustomObjectScope
+    from tensorflow.keras.utils import CustomObjectScope
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,9 +8,9 @@ import numpy as np
 import tensorflow as tf
 from numpy.testing import assert_allclose
 from packaging import version
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.layers import Input, Masking
-from tensorflow.python.keras.models import Model, load_model, save_model
+from tensorflow.keras import backend as K
+from tensorflow.keras.layers import Input, Masking
+from tensorflow.keras.models import Model, load_model, save_model
 
 from deepctr.feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, DEFAULT_GROUP_NAME
 from deepctr.layers import custom_objects

--- a/tests/utils_mtl.py
+++ b/tests/utils_mtl.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.keras.models import load_model, save_model
+from tensorflow.keras.models import load_model, save_model
 
 from deepctr.feature_column import SparseFeat, DenseFeat, DEFAULT_GROUP_NAME
 from deepctr.layers import custom_objects


### PR DESCRIPTION
## Summary

- Split CI coverage across TensorFlow 1.x and 2.x workflows, with TF1 staying on TensorFlow 1.15.5 and TF2 covering modern Python/TensorFlow combinations.
- Add Codecov uploads and terminal missing-line coverage output so CI logs show which files are lowering coverage.
- Replace private `tensorflow.python.keras` imports with public `tensorflow.keras` imports for better TensorFlow 2.x compatibility.
- Update package/docs metadata for the 0.9.4 release and supported Python versions.

## Notes

- `deepctr/estimator` remains supported primarily through the TensorFlow 1.15.5 workflow; modern TensorFlow 2.16+ removes `tf.estimator`.