### PR TITLE
[test] Validate docs-only CI fast-path

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,3 +86,5 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+.. ci-fast-path-smoke-test


### PR DESCRIPTION
Validation complete: docs-only PR triggers CI workflows, runs fast-path step, skips heavy install/pytest/codecov steps, and required build checks conclude success.

Closing this temporary test PR.