### PR TITLE
[codex] Add benchmark suite, model onboarding pipeline, and recent CTR models

### DIFF
--- a/.claude/skills/deepctr-benchmark/SKILL.md
+++ b/.claude/skills/deepctr-benchmark/SKILL.md
@@ -66,6 +66,36 @@ CPU 上 200 万行单 epoch:DeepFM ~60s,慢模型(ONN/DeepFEFM/FiBiNET)数分钟
 模型约 1 小时。要用完整集的官方 train/valid/test 切分(而非我们的随机切分),需给 loader 加多文件
 读取(参照 Census 官方切分的实现)。
 
+### Sequence 真实数据（MovieLens-25M,≥200 万样本）
+
+自带的 `examples/movielens_sample.txt` 只有 200 行(冒烟用);ml-1m 仅 ~100 万评分 → ~99 万样本,
+**不够 200 万**。要 ≥200 万真实序列样本用 **MovieLens-25M**(2500 万评分),切片后合并成 loader
+期望的列(`user_id,movie_id,rating,timestamp,genres,gender`):
+
+```bash
+# 1) 下载并解压（无需 token；约 250MB）
+curl -s -o benchmarks/data/ml-25m.zip \
+  https://files.grouplens.org/datasets/movielens/ml-25m.zip
+python -c "import zipfile; zipfile.ZipFile('benchmarks/data/ml-25m.zip').extractall('benchmarks/data')"
+
+# 2) 取前 ~230 万评分(ml-25m 按 userId 排序)→ ~228 万 (历史→目标) 样本
+python -c "
+import pandas as pd
+r = pd.read_csv('benchmarks/data/ml-25m/ratings.csv', nrows=2_300_000)
+m = pd.read_csv('benchmarks/data/ml-25m/movies.csv')[['movieId','genres']]
+df = r.merge(m, on='movieId', how='left').rename(columns={'userId':'user_id','movieId':'movie_id'})
+df['genres'] = df['genres'].fillna('(no genres listed)')
+df['gender'] = df['user_id'].map(lambda u: 'M' if u % 2 == 0 else 'F')  # ml-25m 无用户画像,确定性合成
+df[['user_id','movie_id','rating','timestamp','genres','gender']].to_csv('benchmarks/data/ml25m_seq_2m.csv', index=False)
+print('samples ~', len(df) - df.user_id.nunique())
+"
+```
+
+样本数 ≈ 评分行数 − 用户数(每个用户首条评分无历史被丢弃)。`gender` 是次要稀疏特征,合成不影响
+序列信号(用户行为历史 → 目标 item/类目)的真实性。CPU 上 228 万样本单 epoch:DIN ~16s、BST ~45s、
+DSIN ~77s(DIEN 在 TF≥2.0 自动 skip)。**注意 GPU 若驱动 PTX 版本与 TF 内核不匹配会全部 failed,
+务必带 `CUDA_VISIBLE_DEVICES=""` 强制 CPU。**
+
 ## 命令
 
 ```bash
@@ -80,6 +110,11 @@ CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track single \
 # 多任务,真实 Census,使用其官方 train/test 切分
 CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track multitask \
   --data-path benchmarks/data/census-income.data --epochs 3 --batch-size 1024
+
+# 序列,真实 MovieLens-25M(先按上文构建 ml25m_seq_2m.csv)
+CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track sequence \
+  --seq-source movielens --data-path benchmarks/data/ml25m_seq_2m.csv \
+  --epochs 1 --batch-size 1024 --embedding-dim 8
 
 # 子集 / 排除慢模型;例如丢掉交互密集的几个以省时间
 #   --models DeepFM,DCN,xDeepFM     只跑这些

--- a/.claude/skills/deepctr-benchmark/SKILL.md
+++ b/.claude/skills/deepctr-benchmark/SKILL.md
@@ -1,103 +1,91 @@
 ---
 name: deepctr-benchmark
 description: >-
-  Run the DeepCTR model benchmark suite (benchmarks/) to validate and compare
-  CTR models end-to-end on real or bundled data, producing a sorted leaderboard.
-  Use when asked to benchmark, compare, validate, or measure DeepCTR models
-  (single-task CTR, multitask, or sequence), or to re-run / extend the
-  benchmark after a code change.
+  运行 DeepCTR 模型 benchmark 套件（benchmarks/），在真实或自带数据上端到端验证、
+  对比 CTR 模型并产出排序后的 leaderboard。当被要求 benchmark、对比、验证或评测
+  DeepCTR 模型（单任务 CTR / 多任务 / 序列），或在改动代码后重跑、扩展 benchmark 时使用。
+  Use to benchmark, compare, or validate DeepCTR CTR models.
 ---
 
-# DeepCTR benchmark suite
+# DeepCTR benchmark 套件
 
-A self-contained harness (`benchmarks/`) that trains DeepCTR models and writes a
-ranked leaderboard. Three tracks: `single` (21 single-task CTR models, Criteo),
-`multitask` (SharedBottom/ESMM/MMOE/PLE, Census-Income), `sequence`
-(DIN/BST/DSIN, DIEN skipped on TF≥2.0). Full docs: `benchmarks/README.md`.
-Curated past results: `benchmarks/RESULTS.md`.
+一个自包含的 harness（`benchmarks/`），训练 DeepCTR 模型并写出排序的 leaderboard。
+三个 track：`single`（21 个单任务 CTR 模型，Criteo）、`multitask`
+（SharedBottom/ESMM/MMOE/PLE，Census-Income）、`sequence`（DIN/BST/DSIN，DIEN 在
+TF≥2.0 上跳过）。完整文档见 `benchmarks/README.md`，历史结果见 `benchmarks/RESULTS.md`。
 
-## Always do these two things first
+## 每次必做的两件事
 
-1. **Force CPU** with `CUDA_VISIBLE_DEVICES=""`. The GPU on this host has a
-   CUDA/PTX mismatch — every model fails with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION`
-   on GPU. The harness isolates each model, so on GPU you get an all-`failed`
-   leaderboard rather than a crash; the fix is always CPU.
-2. **Use legacy Keras**: `TF_USE_LEGACY_KERAS=1` (DeepCTR targets the Keras 2
-   API; on TF≥2.16 that means `tf-keras`). The package sets this itself, but set
-   it explicitly when invoking pytest.
+1. **强制 CPU**：加 `CUDA_VISIBLE_DEVICES=""`。本机 GPU 存在 CUDA/PTX 不兼容，在 GPU 上
+   每个模型都会以 `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` 失败。harness 会逐模型隔离错误，
+   所以在 GPU 上你会得到一张全部 `failed` 的 leaderboard 而非崩溃——解决办法永远是走 CPU。
+2. **用 legacy Keras**：`TF_USE_LEGACY_KERAS=1`（DeepCTR 面向 Keras 2 API；在 TF≥2.16 上
+   即 `tf-keras`）。套件自身会设置它,但用 pytest 调用时要显式设上。
 
-Run long sweeps in the background and poll the log — a full 21-model single-task
-sweep on real data is several minutes to ~30 min on CPU.
+长时间 sweep 放后台跑并轮询日志——真实数据上 21 个单任务模型的完整 sweep 在 CPU 上需要
+几分钟到约 30 分钟。
 
-## Data on this host
+## 本机数据
 
-Real data lives in `benchmarks/data/` (git-ignored). If absent, regenerate or
-re-download (see README; the built-in Criteo DAC URL is dead — anonymous HF
-mirrors rate-limit, so a `HF_TOKEN` is needed for `reczoo/Criteo_x1`).
+真实数据在 `benchmarks/data/`（git-ignored）。若缺失,需重新生成或下载（见 README;内置的
+Criteo DAC URL 已失效——匿名 HF 镜像会限流,下载 `reczoo/Criteo_x1` 需要 `HF_TOKEN`）。
 
-| File | Rows | Use |
+| 文件 | 样本数 | 用途 |
 | ---- | ---- | --- |
-| `benchmarks/data/criteo_x1_500k.csv` | 500,000 | single-task, meaningful AUC |
-| `benchmarks/data/criteo_x1_200k.csv` | 200,000 | single-task, faster |
-| `benchmarks/data/census-income.data` (+ `.test`) | 199,523 (+99,762) | multitask, official split |
-| `examples/criteo_sample.txt` | 200 | smoke only — AUC is noise |
+| `benchmarks/data/criteo_x1_500k.csv` | 500,000 | 单任务,AUC 有意义 |
+| `benchmarks/data/criteo_x1_200k.csv` | 200,000 | 单任务,更快 |
+| `benchmarks/data/census-income.data`（+ `.test`） | 199,523（+99,762） | 多任务,官方切分 |
+| `examples/criteo_sample.txt` | 200 | 仅冒烟——AUC 是噪声 |
 
-## Commands
+## 命令
 
 ```bash
-# Fast smoke test (1 epoch, 2 models/track, bundled data) — verify the harness
+# 快速冒烟（1 epoch、每 track 2 个模型、自带数据）—— 验证 harness 正常
 CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track all --quick
 
-# Single-task, real Criteo 500k — the headline comparison
+# 单任务,真实 Criteo 500k —— 主力对比
 CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track single \
   --data-path benchmarks/data/criteo_x1_500k.csv \
   --epochs 1 --batch-size 1024 --val-split 0 --seed 2020
 
-# Multitask, real Census with its official train/test partition
+# 多任务,真实 Census,使用其官方 train/test 切分
 CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track multitask \
   --data-path benchmarks/data/census-income.data --epochs 3 --batch-size 1024
 
-# Subset / exclude slow models; e.g. drop the interaction-heavy ones to save time
-#   --models DeepFM,DCN,xDeepFM     run only these
-#   --exclude FiBiNET,ONN,DeepFEFM,FwFM,FGCNN   ONN alone is 77M params / ~245s
+# 子集 / 排除慢模型;例如丢掉交互密集的几个以省时间
+#   --models DeepFM,DCN,xDeepFM     只跑这些
+#   --exclude FiBiNET,ONN,DeepFEFM,FwFM,FGCNN   仅 ONN 就有 77M 参数 / 约 245s
 ```
 
-Leaderboards print to stdout and write `benchmarks/results/<track>_<dataset>.csv`
-and `.md`. To preserve a run, copy the numbers into `benchmarks/RESULTS.md`
-(the `results/` dir is git-ignored).
+leaderboard 打印到 stdout,并写出 `benchmarks/results/<track>_<dataset>.csv` 和 `.md`。
+要长期保存一次运行结果,把数字抄进 `benchmarks/RESULTS.md`（`results/` 目录是 git-ignored）。
 
-## Train / test split — get this right
+## 训练 / 测试集划分 —— 这点要做对
 
-- **Default = random split**, `--test-size 0.2`, fixed `--seed`. Correct for
-  Criteo_x1 / DAC, which is anonymised and shuffled with no timestamp (so a
-  random split is leakage-free and standard).
-- **`--temporal-split` (+ optional `--time-col COL`)**: chronological hold-out —
-  the most recent `test_size` fraction becomes the test set, so no future row
-  leaks into training. Sorts by `--time-col` when present, else trusts file
-  order. Use only for time-ordered logs; the bundled Criteo has no timestamp.
-- **Census official split**: when `--data-path` is `census-income.data` and a
-  sibling `census-income.test` exists, the loader uses that official partition
-  automatically (encoders fit on the union). Don't reshuffle it.
-- **`--val-split`** carves validation from *train* but is **not wired to any
-  early-stopping/checkpoint** — it does not influence training or model
-  selection. For short fixed-epoch runs set `--val-split 0` so training uses the
-  full train split; only keep it if you add an EarlyStopping callback.
+- **默认 = 随机切分**,`--test-size 0.2`,固定 `--seed`。对 Criteo_x1 / DAC 是正确的:该数据
+  已匿名化并打散、无时间戳,所以随机切分无穿越且为标准做法。
+- **`--temporal-split`（可选 `--time-col COL`）**:按时间留出——最近 `test_size` 比例作为测试集,
+  杜绝未来行泄漏进训练。有 `--time-col` 时按它排序,否则信任文件既有顺序。仅用于带时间顺序的
+  日志;自带的 Criteo 没有时间戳。
+- **Census 官方切分**:当 `--data-path` 为 `census-income.data` 且同目录存在 `census-income.test`
+  时,loader 自动使用官方划分（编码器在并集上 fit）。不要再把它打散重切。
+- **`--val-split`** 从训练集中切出验证集,但**没有接任何早停 / checkpoint**——它不影响训练过程
+  也不参与模型选择。固定 epoch 的短跑应设 `--val-split 0`,让训练用满整个训练集;只有在加了
+  EarlyStopping callback 时才保留它。
 
-## Interpreting results
+## 结果解读
 
-- Reported AUC/LogLoss are on the held-out **test** set (never seen in `fit`).
-- Need enough data for a real ranking: on 200-row bundled data AUC ≈ 0.5 noise;
-  on 200k–500k the deep interaction models (DeepFEFM/FiBiNET/DeepFM/xDeepFM)
-  separate from simpler ones. More epochs raise absolute AUC but rarely flip the
-  top group.
-- Always report the split and epoch count alongside the leaderboard — a ranking
-  is only comparable within the same data/split/epochs.
+- 报告的 AUC/LogLoss 来自 hold-out 的**测试集**（`fit` 从未见过）。
+- 要有足够数据才有真实排名:200 行自带数据上 AUC≈0.5 是噪声;到 200k–500k 时,深层交互模型
+  （DeepFEFM/FiBiNET/DeepFM/xDeepFM）才与简单模型拉开。更多 epoch 会抬高绝对 AUC,但很少改变
+  头部梯队。
+- 汇报 leaderboard 时务必同时注明切分方式与 epoch 数——排名只在相同 数据/切分/epoch 下可比。
 
-## Tests
+## 测试
 
 ```bash
 CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 python -m pytest tests/benchmark_test.py -q
 ```
 
-Covers each track on tiny data plus the split guarantees (temporal hold-out
-keeps the most-recent rows as test; Census uses the official `.test`).
+覆盖每个 track 在小数据上的运行,以及切分保证（时序留出把最近的行作为测试集;Census 使用
+官方 `.test`）。

--- a/.claude/skills/deepctr-benchmark/SKILL.md
+++ b/.claude/skills/deepctr-benchmark/SKILL.md
@@ -37,6 +37,35 @@ Criteo DAC URL 已失效——匿名 HF 镜像会限流,下载 `reczoo/Criteo_x1
 | `benchmarks/data/census-income.data`（+ `.test`） | 199,523（+99,762） | 多任务,官方切分 |
 | `examples/criteo_sample.txt` | 200 | 仅冒烟——AUC 是噪声 |
 
+上面的 `criteo_x1_*` 是 **FuxiCTR Criteo_x1 完整集**(~4584 万行)的切片。需要更大规模时,下载完整集
+并按需截取(不要把完整集直接喂给 loader——它会把整个文件读进 pandas):
+
+```bash
+# 1) 下载完整集（2.9GB zip，需 HF token；匿名会被限流）
+curl -L -C - -H "Authorization: Bearer $HF_TOKEN" \
+  -o benchmarks/data/Criteo_x1.zip \
+  "https://huggingface.co/datasets/reczoo/Criteo_x1/resolve/main/Criteo_x1.zip"
+# zip 内含官方 8:1:1 切分: train.csv(8.2GB) / valid.csv(2.0GB) / test.csv(1.1GB)
+# 列格式与切片一致: label,I1..I13,C1..C26（带表头）
+
+# 2) 流式抽取前 N 行（避免解压/读入整个 8.2GB），生成自定义规模切片
+python -c "
+import zipfile, io
+N = 2_000_000
+z = zipfile.ZipFile('benchmarks/data/Criteo_x1.zip')
+with z.open('train.csv') as raw, io.TextIOWrapper(raw) as fin, \
+     open('benchmarks/data/criteo_x1_2m.csv','w') as fo:
+    fo.write(fin.readline())            # 表头
+    for i, line in enumerate(fin):
+        if i >= N: break
+        fo.write(line)
+"
+```
+
+CPU 上 200 万行单 epoch:DeepFM ~60s,慢模型(ONN/DeepFEFM/FiBiNET)数分钟到十几分钟;全量 21
+模型约 1 小时。要用完整集的官方 train/valid/test 切分(而非我们的随机切分),需给 loader 加多文件
+读取(参照 Census 官方切分的实现)。
+
 ## 命令
 
 ```bash

--- a/.claude/skills/deepctr-benchmark/SKILL.md
+++ b/.claude/skills/deepctr-benchmark/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: deepctr-benchmark
+description: >-
+  Run the DeepCTR model benchmark suite (benchmarks/) to validate and compare
+  CTR models end-to-end on real or bundled data, producing a sorted leaderboard.
+  Use when asked to benchmark, compare, validate, or measure DeepCTR models
+  (single-task CTR, multitask, or sequence), or to re-run / extend the
+  benchmark after a code change.
+---
+
+# DeepCTR benchmark suite
+
+A self-contained harness (`benchmarks/`) that trains DeepCTR models and writes a
+ranked leaderboard. Three tracks: `single` (21 single-task CTR models, Criteo),
+`multitask` (SharedBottom/ESMM/MMOE/PLE, Census-Income), `sequence`
+(DIN/BST/DSIN, DIEN skipped on TF≥2.0). Full docs: `benchmarks/README.md`.
+Curated past results: `benchmarks/RESULTS.md`.
+
+## Always do these two things first
+
+1. **Force CPU** with `CUDA_VISIBLE_DEVICES=""`. The GPU on this host has a
+   CUDA/PTX mismatch — every model fails with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION`
+   on GPU. The harness isolates each model, so on GPU you get an all-`failed`
+   leaderboard rather than a crash; the fix is always CPU.
+2. **Use legacy Keras**: `TF_USE_LEGACY_KERAS=1` (DeepCTR targets the Keras 2
+   API; on TF≥2.16 that means `tf-keras`). The package sets this itself, but set
+   it explicitly when invoking pytest.
+
+Run long sweeps in the background and poll the log — a full 21-model single-task
+sweep on real data is several minutes to ~30 min on CPU.
+
+## Data on this host
+
+Real data lives in `benchmarks/data/` (git-ignored). If absent, regenerate or
+re-download (see README; the built-in Criteo DAC URL is dead — anonymous HF
+mirrors rate-limit, so a `HF_TOKEN` is needed for `reczoo/Criteo_x1`).
+
+| File | Rows | Use |
+| ---- | ---- | --- |
+| `benchmarks/data/criteo_x1_500k.csv` | 500,000 | single-task, meaningful AUC |
+| `benchmarks/data/criteo_x1_200k.csv` | 200,000 | single-task, faster |
+| `benchmarks/data/census-income.data` (+ `.test`) | 199,523 (+99,762) | multitask, official split |
+| `examples/criteo_sample.txt` | 200 | smoke only — AUC is noise |
+
+## Commands
+
+```bash
+# Fast smoke test (1 epoch, 2 models/track, bundled data) — verify the harness
+CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track all --quick
+
+# Single-task, real Criteo 500k — the headline comparison
+CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track single \
+  --data-path benchmarks/data/criteo_x1_500k.csv \
+  --epochs 1 --batch-size 1024 --val-split 0 --seed 2020
+
+# Multitask, real Census with its official train/test partition
+CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track multitask \
+  --data-path benchmarks/data/census-income.data --epochs 3 --batch-size 1024
+
+# Subset / exclude slow models; e.g. drop the interaction-heavy ones to save time
+#   --models DeepFM,DCN,xDeepFM     run only these
+#   --exclude FiBiNET,ONN,DeepFEFM,FwFM,FGCNN   ONN alone is 77M params / ~245s
+```
+
+Leaderboards print to stdout and write `benchmarks/results/<track>_<dataset>.csv`
+and `.md`. To preserve a run, copy the numbers into `benchmarks/RESULTS.md`
+(the `results/` dir is git-ignored).
+
+## Train / test split — get this right
+
+- **Default = random split**, `--test-size 0.2`, fixed `--seed`. Correct for
+  Criteo_x1 / DAC, which is anonymised and shuffled with no timestamp (so a
+  random split is leakage-free and standard).
+- **`--temporal-split` (+ optional `--time-col COL`)**: chronological hold-out —
+  the most recent `test_size` fraction becomes the test set, so no future row
+  leaks into training. Sorts by `--time-col` when present, else trusts file
+  order. Use only for time-ordered logs; the bundled Criteo has no timestamp.
+- **Census official split**: when `--data-path` is `census-income.data` and a
+  sibling `census-income.test` exists, the loader uses that official partition
+  automatically (encoders fit on the union). Don't reshuffle it.
+- **`--val-split`** carves validation from *train* but is **not wired to any
+  early-stopping/checkpoint** — it does not influence training or model
+  selection. For short fixed-epoch runs set `--val-split 0` so training uses the
+  full train split; only keep it if you add an EarlyStopping callback.
+
+## Interpreting results
+
+- Reported AUC/LogLoss are on the held-out **test** set (never seen in `fit`).
+- Need enough data for a real ranking: on 200-row bundled data AUC ≈ 0.5 noise;
+  on 200k–500k the deep interaction models (DeepFEFM/FiBiNET/DeepFM/xDeepFM)
+  separate from simpler ones. More epochs raise absolute AUC but rarely flip the
+  top group.
+- Always report the split and epoch count alongside the leaderboard — a ranking
+  is only comparable within the same data/split/epochs.
+
+## Tests
+
+```bash
+CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 python -m pytest tests/benchmark_test.py -q
+```
+
+Covers each track on tiny data plus the split guarantees (temporal hold-out
+keeps the most-recent rows as test; Census uses the official `.test`).

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.h5
 *.ipynb
 .pytest_cache/
+
+# DeepCTR benchmark suite: downloaded datasets and generated leaderboards
+benchmarks/data/
+benchmarks/results/
 .vscode/
 tests/unused/*
 # Byte-compiled / optimized / DLL files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,18 @@ CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 python -m pytest tests/ -q
 CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 python -m pytest tests/models/DeepFM_test.py -q   # single model
 ```
 
+## Correctness contract for model work
+
+- A training smoke test is not proof of mathematical correctness. Follow the
+  C0-C6 ladder in `tests/README.md`.
+- Every model uses `check_model` / `check_mtl_model` for finite inference and
+  prediction-equivalent weight/full-model serialization.
+- Every custom mathematical layer adds an independent NumPy equation test plus
+  finite gradients via `tests/correctness.py`; add numerical gradients on tiny
+  tensors and domain invariants for masking, causality, symmetry, or padding.
+- Benchmark AUC validates effectiveness only. Claim paper reproduction only
+  after an official-code differential or matching paper-scale protocol.
+
 ## Adding a new model — use the onboarding pipeline
 
 The `benchmarks.onboard` CLI standardizes adding a new CTR model across four

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+Guidance for AI agents (Codex, Claude Code, etc.) working in this repo.
+
+## Environment setup (required before running tests or benchmarks)
+
+DeepCTR targets the **Keras 2** API. This box ships TF with Keras 3, so you must
+install legacy Keras and force it on, or every model test fails on label-rank /
+serialization errors.
+
+```bash
+pip install pytest                       # not preinstalled
+pip install "tf-keras==<TF major.minor>" # e.g. tf-keras==2.19.0 for TF 2.19; required on TF>=2.16
+```
+
+Prefix every test / benchmark / onboarding command with:
+
+```bash
+CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 <command>
+```
+
+(`CUDA_VISIBLE_DEVICES=""` avoids a GPU CUDA/PTX mismatch; `TF_USE_LEGACY_KERAS=1`
+selects the Keras-2 backend.)
+
+## Running tests
+
+```bash
+CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 python -m pytest tests/ -q
+CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 python -m pytest tests/models/DeepFM_test.py -q   # single model
+```
+
+## Adding a new model — use the onboarding pipeline
+
+The `benchmarks.onboard` CLI standardizes adding a new CTR model across four
+stages. Full reference: `benchmarks/onboard/README.md`.
+
+```bash
+export CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1
+
+python -m benchmarks.onboard discover --list                       # candidate models
+python -m benchmarks.onboard scaffold <Name> --category single     # codegen + auto-wire all registration points
+#   -> implement the model core in deepctr/models/<name>.py (replace the TODO block)
+python -m benchmarks.onboard verify <Name>                         # unit test + audit + benchmark vs baseline
+python -m benchmarks.onboard docs   <Name>                         # update README/Features/rst/History/RESULTS
+python -m benchmarks.onboard audit                                 # confirm every model is fully wired
+```
+
+Categories: `single` | `sequence` | `multitask`. Add `--with-layer` to also
+scaffold a custom layer, `--wire-only` for an already-written model.
+
+### Gotchas
+
+- `scaffold` generates `tests/models/<Name>_test.py` with a **generic** constructor
+  signature (`dnn_hidden_units=...`). If your model's signature differs, edit the
+  generated test to pass the right args (e.g. FinalMLP uses `mlp1_hidden_units`).
+- Every custom layer must end up in `deepctr/layers/__init__.py` `custom_objects`
+  (scaffold does this), create sub-layers in `__init__` not `build`, avoid
+  `Lambda(lambda ...)` (use a small serializable layer), and not collide on class
+  name with another registered layer — or `save_model`/`load_model` will fail.
+  Run `python -m benchmarks.onboard audit` to verify wiring.
+
+## Conventions
+
+- Models are factory functions returning a `tf.keras.Model`; see `deepctr/models/wdl.py`
+  (single), `deepctr/models/sequence/din.py` (sequence), `deepctr/models/multitask/mmoe.py`.
+- Use `tensorflow.keras` imports (not `tensorflow.python.keras`).
+- Commit only when asked; branch off `master` for PRs.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Introduction](https://zhuanlan.zhihu.com/p/53231955)) and [welcome to join us!](
 |   MMOE                    | [KDD 2018][Modeling Task Relationships in Multi-task Learning with Multi-gate Mixture-of-Experts](https://dl.acm.org/doi/abs/10.1145/3219819.3220007)                   |
 |   PLE                    | [RecSys 2020][Progressive Layered Extraction (PLE): A Novel Multi-Task Learning (MTL) Model for Personalized Recommendations](https://dl.acm.org/doi/10.1145/3383313.3412236)                   |
 |   EDCN                   | [KDD 2021][Enhancing Explicit and Implicit Feature Interactions via Information Sharing for Parallel Deep CTR Models](https://dlp-kdd.github.io/assets/pdf/DLP-KDD_2021_paper_12.pdf)                   |
+|   OneTrans                   | [industrial 2024][OneTrans: Unified Feature Interaction and Sequence Modeling with One Transformer in Industrial Recommender Systems]()   |
+|   FinalMLP                   | [AAAI 2023][FinalMLP: An Enhanced Two-Stream MLP Model for CTR Prediction](https://arxiv.org/abs/2304.00902)   |
+|   MaskNet                   | [DLP-KDD 2021][MaskNet: Introducing Feature-Wise Multiplication to CTR Ranking Models by Instance-Guided Mask](https://arxiv.org/abs/2102.07619)   |
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Introduction](https://zhuanlan.zhihu.com/p/53231955)) and [welcome to join us!](
 |   OneTrans                   | [industrial 2024][OneTrans: Unified Feature Interaction and Sequence Modeling with One Transformer in Industrial Recommender Systems]()   |
 |   FinalMLP                   | [AAAI 2023][FinalMLP: An Enhanced Two-Stream MLP Model for CTR Prediction](https://arxiv.org/abs/2304.00902)   |
 |   MaskNet                   | [DLP-KDD 2021][MaskNet: Introducing Feature-Wise Multiplication to CTR Ranking Models by Instance-Guided Mask](https://arxiv.org/abs/2102.07619)   |
+|   WuKong                   | [ICML 2024][Wukong: Towards a Scaling Law for Large-Scale Recommendation](https://arxiv.org/abs/2403.02545)   |
 
 ## Citation
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,151 @@
+# DeepCTR benchmark suite
+
+A small, self-contained harness that trains and compares DeepCTR models
+end-to-end and writes a sorted **leaderboard**. It covers three tracks:
+
+| Track | Models | Dataset | Metrics |
+| --- | --- | --- | --- |
+| `single` | 21 single-task CTR models | Criteo (binary) | AUC, LogLoss |
+| `multitask` | SharedBottom, ESMM, MMOE, PLE | Census-Income (2 tasks) | per-task AUC/LogLoss, mean_AUC |
+| `sequence` | DIN, BST, DSIN (DIEN¹) | synthetic / MovieLens | AUC, LogLoss |
+
+¹ DIEN is **skipped on TensorFlow ≥ 2.0** — its GRU/AUGRU layers depend on
+legacy TF1 private RNN APIs (its own unit test skips on TF2).
+
+## Install
+
+The core `deepctr` library stays dependency-lean, so the benchmark has a few
+extras of its own. Install TensorFlow first (per the project README), then:
+
+```bash
+pip install -r benchmarks/requirements.txt      # scikit-learn, pandas
+```
+
+**TensorFlow ≥ 2.16 (Keras 3) users:** DeepCTR targets the Keras 2 API, so the
+suite runs under *legacy Keras* — exactly like the project CI. Install the
+matching `tf-keras` and the suite sets `TF_USE_LEGACY_KERAS=1` for you:
+
+```bash
+pip install tf-keras~=2.19.0     # match your TensorFlow minor version
+```
+
+(On TF 1.15 / 2.x-with-Keras-2 nothing extra is needed.)
+
+## Quick start
+
+```bash
+# Fast self-test: 1 epoch, 2 models per track, bundled/tiny data
+python -m benchmarks.benchmark --track single --quick
+
+# Full single-task leaderboard on the bundled 200-row Criteo sample
+python -m benchmarks.benchmark --track single
+
+# All three tracks
+python -m benchmarks.benchmark --track all
+```
+
+Each run prints a leaderboard and writes `benchmarks/results/<track>_<dataset>.csv`
+and `.md` (git-ignored).
+
+## Datasets
+
+### Criteo (single-task)
+
+The bundled `examples/criteo_sample.txt` has only 200 rows — fine to verify the
+pipeline, **not** for meaningful AUC. For real numbers:
+
+```bash
+# Try the Criteo "DAC" ~100k-row sample (downloads once into benchmarks/data/)
+python -m benchmarks.benchmark --track single --download --epochs 5
+
+# ...or point at any full Criteo file (TSV, no header: label + I1..I13 + C1..C26)
+python -m benchmarks.benchmark --track single --data-path /path/to/train.txt --epochs 5
+
+# High-cardinality full data: hash sparse features instead of label-encoding
+python -m benchmarks.benchmark --track single --data-path train.txt --hash --max-rows 1000000
+```
+
+The downloader is best-effort: the historical Criteo URL is fragile, so if it is
+unreachable the loader prints manual-download instructions and falls back to the
+bundled sample (it never hard-fails). Override the URL with `--download-url`.
+
+### Census-Income (multitask)
+
+Uses the bundled `examples/census-income.sample`; pass the full UCI
+Census-Income KDD `.data` file via `--data-path`. Two derived binary tasks:
+`label_income` (>50k) and `label_marital` (never-married).
+
+> ESMM assumes sequentially-dependent CTR→CTCVR tasks; on Census it still runs,
+> but its numbers are not directly comparable to the other multitask models.
+
+### Sequence
+
+`--seq-source synthetic` (default) deterministically generates user behavior
+sequences with an **injected, learnable signal** (the label depends on whether
+the target item is in the user's history and on the user's favourite category).
+Synthetic AUC is modest with default model sizes — its purpose is to confirm all
+sequence models build/train/predict and to compare their **cost** (params, train
+time). For real predictive comparison use `--seq-source movielens --data-path
+ml-1m/ratings...` (the bundled 200-row MovieLens file is only a smoke test);
+Amazon-Electronics is the canonical heavy benchmark and is left as an extension.
+
+## Common flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--track` | `single` | `single` / `multitask` / `sequence` / `all` |
+| `--models a,b` | all | run only these models |
+| `--exclude a,b` | – | skip these models |
+| `--epochs` | 5 | training epochs |
+| `--batch-size` | 256 | |
+| `--embedding-dim` | 8 | uniform sparse embedding size |
+| `--val-split` / `--test-size` | 0.2 / 0.2 | |
+| `--seed` | 2020 | seeds python/numpy/TF |
+| `--quick` | off | 1 epoch, 2 models/track, small data |
+| `--source` / `--download` / `--data-path` | bundled | Criteo source |
+| `--seq-source` / `--n-samples` / `--sess-max-count` / `--sess-len` | synthetic / 2000 / 3 / 4 | sequence options |
+| `--output-dir` | `benchmarks/results` | leaderboard output |
+
+## Output
+
+The leaderboard ranks `status=ok` models by the headline metric (AUC desc /
+mean_AUC desc / RMSE asc), with skipped/failed models listed below:
+
+```
+| Rank | Model   | Status | AUC    | LogLoss | Params  | Train(s) | Note |
+| ---- | ------- | ------ | ------ | ------- | ------- | -------- | ---- |
+| 1    | DCNMix  | ok     | 0.6022 | 0.7255  | 124,000 | 8.8      |      |
+| 2    | DeepFM  | ok     | 0.5842 | 0.7297  | 118,564 | 6.8      |      |
+| -    | DIEN    | skipped|        |         |         |          | DIEN's GRU/AUGRU ... unsupported on TF>=2.0 |
+```
+
+Every model runs in isolation (`clear_session()` + `try/except`), so one failing
+model never aborts the sweep — it is recorded as `failed` with the error.
+
+## Model-specific notes
+
+- **AFM, CCPM, EDCN** are sparse-only (`support_dense=False`); the registry
+  drops `DenseFeat` from their inputs automatically.
+- **FLEN** needs ≥2 field groups; the registry round-robins the sparse features
+  into synthetic groups (Criteo has no field taxonomy).
+- **PNN** has no linear part; **MLR** uses the feature columns as both its region
+  and base inputs.
+- **ONN, FiBiNET, DeepFEFM, FwFM** build many pairwise/field interactions and are
+  noticeably slower to construct than the rest.
+
+## Extending
+
+Add a model by registering a builder in `benchmarks/registry.py`:
+
+```python
+SINGLE_TASK_MODELS["MyModel"] = lambda lin, dnn, task: MyModel(lin, dnn, task=task)
+```
+
+Datasets live in `benchmarks/datasets/` and return the typed containers in
+`benchmarks/common.py` (`SingleTaskData` / `MultiTaskData` / `SequenceData`).
+
+## Test
+
+```bash
+TF_USE_LEGACY_KERAS=1 pytest tests/benchmark_test.py -q
+```

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -75,6 +75,13 @@ Uses the bundled `examples/census-income.sample`; pass the full UCI
 Census-Income KDD `.data` file via `--data-path`. Two derived binary tasks:
 `label_income` (>50k) and `label_marital` (never-married).
 
+> When `--data-path` points at `census-income.data` and its sibling
+> `census-income.test` exists, the loader uses the dataset's **official
+> train/test partition** (199,523 / 99,762 rows) instead of a random split —
+> the canonical evaluation. Encoders are fit on the union so test-only
+> categories don't crash the run. The bundled sample has no `.test` sibling and
+> falls back to a random split.
+
 > ESMM assumes sequentially-dependent CTR→CTCVR tasks; on Census it still runs,
 > but its numbers are not directly comparable to the other multitask models.
 
@@ -100,6 +107,7 @@ Amazon-Electronics is the canonical heavy benchmark and is left as an extension.
 | `--batch-size` | 256 | |
 | `--embedding-dim` | 8 | uniform sparse embedding size |
 | `--val-split` / `--test-size` | 0.2 / 0.2 | |
+| `--temporal-split` / `--time-col` | off / – | single-task: chronological hold-out (most recent `--test-size` as test) instead of a random split — for time-ordered logs, to avoid leakage. Sorts by `--time-col` when given, else trusts file order. (The bundled/Criteo_x1 data is anonymised & shuffled with no timestamp, so it stays on the random split.) |
 | `--seed` | 2020 | seeds python/numpy/TF |
 | `--quick` | off | 1 epoch, 2 models/track, small data |
 | `--source` / `--download` / `--data-path` | bundled | Criteo source |

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -172,3 +172,4 @@ Auto-recorded verify outcomes for models added through `benchmarks.onboard`.
 - **OneTrans**: see `benchmarks/onboard/reports/OneTrans.md`
 - **FinalMLP**: see `benchmarks/onboard/reports/FinalMLP.md`
 - **MaskNet**: see `benchmarks/onboard/reports/MaskNet.md`
+- **WuKong**: see `benchmarks/onboard/reports/WuKong.md`

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -120,6 +120,27 @@ batch 1024. Tasks: `label_income` (>50k), `label_marital` (never-married).
   sequentially-dependent CTR→CTCVR tasks, which Census does not satisfy. Its
   numbers are not directly comparable.
 
+## Sequence — real MovieLens-25M `ml25m_seq_2m.csv` (current headline)
+
+**2,284,710** behavior samples built from the first 2.3M ratings of MovieLens-25M
+(per user, sorted by timestamp: target = current movie, history = up to 12 prior
+movies, label = rating ≥ 4, cate = first genre). 29,273 items · random split
+(seed=2020, test_size=0.2). 1 epoch, batch 1024, embedding-dim 8, **CPU**.
+
+| Rank | Model | AUC | LogLoss | Params | Train(s) |
+| ---- | ----- | --- | ------- | ------ | -------- |
+| 1 | DIN | **0.8021** | 0.5408 | 419,194 | 16.3 |
+| 2 | DSIN | 0.7951 | 0.5471 | 436,635 | 77.2 |
+| 3 | BST | 0.7943 | 0.5487 | 419,162 | 45.0 |
+| - | DIEN | skipped | — | — | — | GRU/AUGRU need legacy TF1 RNN APIs; unsupported on TF≥2.0 |
+
+- On real sequences all three models land at **0.79–0.80 AUC** — a genuine signal,
+  unlike the ~0.5 synthetic track (which only checks build/train/predict + cost).
+- **DIN is the value pick**: top AUC *and* fastest (16s). DSIN edges out BST but
+  costs ~4.7× the train time — its session structure earns nothing at 1 epoch.
+- MovieLens-25M has no user demographics, so `gender` (a minor sparse feature) is
+  synthesized deterministically from `user_id`; the sequence signal is fully real.
+
 ## Sequence — synthetic
 
 DIN / BST / DSIN build, train and predict; **DIEN is skipped on TF≥2.0** (its
@@ -138,4 +159,9 @@ CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track single \
 
 CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track multitask \
   --data-path benchmarks/data/census-income.data --epochs 3 --batch-size 1024
+
+# Sequence on real MovieLens-25M (build ml25m_seq_2m.csv first — see the skill)
+CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track sequence \
+  --seq-source movielens --data-path benchmarks/data/ml25m_seq_2m.csv \
+  --epochs 1 --batch-size 1024 --embedding-dim 8
 ```

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -10,6 +10,50 @@ curated, version-controlled snapshot.
 > `TF_USE_LEGACY_KERAS=1`). Absolute AUCs are not tuned maxima — the value is in
 > the **relative ranking and cost** under a fixed, leakage-free split.
 
+## Single-task CTR — real Criteo `criteo_x1_2m.csv` (current headline)
+
+2,000,000 samples sliced from the full Criteo_x1 `train.csv` · **random split,
+seed=2020 → 1,600,000 train / 400,000 test** (`--val-split 0`). 1 epoch, batch
+1024, embedding-dim 8.
+
+| Rank | Model | AUC | LogLoss | Params | Train(s) |
+| ---- | ----- | --- | ------- | ------ | -------- |
+| 1 | DeepFEFM | 0.7914 | 0.4541 | 7.5M | 332 |
+| 2 | FiBiNET | 0.7913 | 0.4542 | 8.7M | 188 |
+| 3 | PNN | 0.7901 | 0.4552 | 6.7M | 72 |
+| 4 | ONN | 0.7900 | 0.4556 | 163.8M | 1304 |
+| 5 | DeepFM | 0.7893 | 0.4558 | 7.4M | 60 |
+| 6 | xDeepFM | 0.7892 | 0.4560 | 7.7M | 163 |
+| 7 | FwFM | 0.7887 | 0.4563 | 7.4M | 307 |
+| 8 | FNN | 0.7886 | 0.4565 | 6.6M | 55 |
+| 9 | DCN | 0.7885 | 0.4564 | 7.4M | 71 |
+| 10 | WDL | 0.7885 | 0.4565 | 7.4M | 61 |
+| 11 | FLEN | 0.7884 | 0.4565 | 7.4M | 68 |
+| 12 | AutoInt | 0.7882 | 0.4570 | 7.4M | 129 |
+| 13 | DCNMix | 0.7879 | 0.4569 | 7.5M | 186 |
+| 14 | NFM | 0.7872 | 0.4575 | 7.3M | 56 |
+| 15 | FGCNN | 0.7807 | 0.4629 | 15.8M | 500 |
+| 16 | DIFM | 0.7795 | 0.4639 | 7.4M | 116 |
+| 17 | IFM | 0.7784 | 0.4647 | 7.4M | 58 |
+| 18 | MLR | 0.7753 | 0.4681 | 6.5M | 44 |
+| 19 | CCPM | 0.7579 | 0.4807 | 7.3M | 90 |
+| 20 | EDCN | 0.7543 | 0.4819 | 7.6M | 82 |
+| 21 | AFM | 0.7495 | 0.4861 | 7.3M | 93 |
+
+**Cross-scale (same random split, 1 epoch unless noted)**
+
+| Model | 200k (3ep) | 500k (1ep) | 2M (1ep) |
+| ----- | ---------- | ---------- | -------- |
+| DeepFM | 0.745 | 0.7794 | **0.7893** |
+| DeepFEFM | (excluded) | 0.7817 | **0.7914** |
+| FiBiNET | (excluded) | 0.7797 | **0.7913** |
+
+- **Data volume is the biggest lever**: DeepFM gains ~0.01 AUC from 500k→2M,
+  more than swapping architectures buys — the top 14 models sit within 0.787–0.791.
+- DeepFEFM / FiBiNET stay #1/#2; **PNN climbs to #3** at scale.
+- **ONN catches up on AUC at 2M (0.7900) but is absurdly costly**: 163.8M params
+  and ~22 min (22× DeepFM's 60s). Not worth it.
+
 ## Single-task CTR — real Criteo `criteo_x1_500k.csv`
 
 500,000 samples · **random split, seed=2020 → 400,000 train / 100,000 test**

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -165,3 +165,10 @@ CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track sequence \
   --seq-source movielens --data-path benchmarks/data/ml25m_seq_2m.csv \
   --epochs 1 --batch-size 1024 --embedding-dim 8
 ```
+
+## Onboarded via pipeline <!-- onboard:results -->
+
+Auto-recorded verify outcomes for models added through `benchmarks.onboard`.
+- **OneTrans**: see `benchmarks/onboard/reports/OneTrans.md`
+- **FinalMLP**: see `benchmarks/onboard/reports/FinalMLP.md`
+- **MaskNet**: see `benchmarks/onboard/reports/MaskNet.md`

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,0 +1,97 @@
+# DeepCTR benchmark results
+
+Real-data leaderboards produced by `benchmarks/benchmark.py`. The raw
+`benchmarks/results/*.{csv,md}` are git-ignored (generated); this file is the
+curated, version-controlled snapshot.
+
+> **Environment note.** All runs below were executed **CPU-only**
+> (`CUDA_VISIBLE_DEVICES=""`) because the GPU on the run host had a CUDA/PTX
+> mismatch. TensorFlow 2.19 + `tf-keras` 2.19 (legacy Keras,
+> `TF_USE_LEGACY_KERAS=1`). Absolute AUCs are not tuned maxima — the value is in
+> the **relative ranking and cost** under a fixed, leakage-free split.
+
+## Single-task CTR — real Criteo `criteo_x1_500k.csv`
+
+500,000 samples · **random split, seed=2020 → 400,000 train / 100,000 test**
+(no validation carve-out: `--val-split 0`, since 1 epoch + no early stopping
+makes a validation set dead weight). 1 epoch, batch 1024, embedding-dim 8.
+The Criteo_x1 (Kaggle DAC) data is anonymised and shuffled with no timestamp,
+so a random split is the standard, leakage-free choice.
+
+| Rank | Model | AUC | LogLoss | Params | Train(s) |
+| ---- | ----- | --- | ------- | ------ | -------- |
+| 1 | DeepFEFM | 0.7817 | 0.4664 | 3.6M | 130.4 |
+| 2 | FiBiNET | 0.7797 | 0.4680 | 4.8M | 104.8 |
+| 3 | DeepFM | 0.7794 | 0.4682 | 3.5M | 13.2 |
+| 4 | xDeepFM | 0.7793 | 0.4683 | 3.8M | 39.1 |
+| 5 | FwFM | 0.7791 | 0.4684 | 3.5M | 103.1 |
+| 6 | DCN | 0.7790 | 0.4687 | 3.5M | 16.3 |
+| 7 | PNN | 0.7790 | 0.4687 | 3.2M | 14.8 |
+| 8 | WDL | 0.7790 | 0.4685 | 3.5M | 13.7 |
+| 9 | FNN | 0.7789 | 0.4686 | 3.1M | 10.0 |
+| 10 | FLEN | 0.7789 | 0.4686 | 3.5M | 15.3 |
+| 11 | AutoInt | 0.7787 | 0.4688 | 3.5M | 32.5 |
+| 12 | DCNMix | 0.7786 | 0.4690 | 3.6M | 47.1 |
+| 13 | NFM | 0.7779 | 0.4695 | 3.5M | 15.8 |
+| 14 | ONN | 0.7602 | 0.4955 | 77.0M | 244.7 |
+| 15 | DIFM | 0.7525 | 0.4879 | 3.6M | 29.5 |
+| 16 | MLR | 0.7499 | 0.4935 | 3.0M | 26.6 |
+| 17 | FGCNN | 0.7495 | 0.4896 | 8.4M | 122.6 |
+| 18 | IFM | 0.7447 | 0.4927 | 3.5M | 14.4 |
+| 19 | CCPM | 0.7445 | 0.4934 | 3.4M | 20.6 |
+| 20 | EDCN | 0.7395 | 0.4970 | 3.7M | 18.0 |
+| 21 | AFM | 0.7282 | 0.5092 | 3.4M | 19.7 |
+
+**Takeaways**
+
+- Explicit feature-interaction deep models (**DeepFEFM, FiBiNET, DeepFM,
+  xDeepFM**) lead once there is enough data. An earlier 200k / 3-epoch run that
+  excluded the slow interaction models had MLR/NFM on top — a small-data
+  artifact, not a real ranking.
+- The top 13 models sit in a tight 0.778–0.782 band (1 epoch is not converged),
+  but are clearly separated from the tail (AFM 0.728, EDCN 0.740).
+- **Cost outlier: ONN** — 77M params and 245s to train for only 0.76 AUC.
+  DeepFEFM/FiBiNET/FwFM/FGCNN cost ~100–130s (≈10× DeepFM's 13s); only
+  DeepFEFM/FiBiNET earn it with a top-of-board AUC.
+
+## Multitask — real UCI Census-Income (official split)
+
+**Official train/test partition: 199,523 train / 99,762 test** (loader uses the
+shipped `census-income.test` when present, not a random reshuffle). 3 epochs,
+batch 1024. Tasks: `label_income` (>50k), `label_marital` (never-married).
+
+| Rank | Model | income AUC | marital AUC | mean_AUC | Params | Train(s) |
+| ---- | ----- | ---------- | ----------- | -------- | ------ | -------- |
+| 1 | SharedBottom | 0.9465 | 0.9943 | 0.9704 | 116K | 8.1 |
+| 2 | MMOE | 0.9465 | 0.9942 | 0.9704 | 308K | 11.0 |
+| 3 | PLE | 0.9462 | 0.9943 | 0.9703 | 424K | 17.3 |
+| 4 | ESMM | 0.5632 | 0.9751 | 0.7692 | 211K | 8.5 |
+
+**Takeaways**
+
+- On Census the three general multitask architectures are statistically
+  indistinguishable (mean_AUC 0.9703–0.9704); the task is easy enough that the
+  extra capacity of MMOE/PLE buys nothing here. SharedBottom wins on cost.
+- **ESMM is far behind** (income AUC 0.56) — expected: it assumes
+  sequentially-dependent CTR→CTCVR tasks, which Census does not satisfy. Its
+  numbers are not directly comparable.
+
+## Sequence — synthetic
+
+DIN / BST / DSIN build, train and predict; **DIEN is skipped on TF≥2.0** (its
+GRU/AUGRU layers need legacy TF1 private RNN APIs). Synthetic AUC is ~0.5 by
+design — the synthetic track verifies the models run and compares their cost,
+not predictive power. Use `--seq-source movielens`/Amazon for real numbers.
+
+## Reproduce
+
+See `.claude/skills/deepctr-benchmark` for the exact commands, or:
+
+```bash
+CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track single \
+  --data-path benchmarks/data/criteo_x1_500k.csv \
+  --epochs 1 --batch-size 1024 --val-split 0 --seed 2020
+
+CUDA_VISIBLE_DEVICES="" python -m benchmarks.benchmark --track multitask \
+  --data-path benchmarks/data/census-income.data --epochs 3 --batch-size 1024
+```

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,24 @@
+"""DeepCTR model evaluation / benchmark suite.
+
+A small, self-contained harness that trains and compares DeepCTR models
+end-to-end across three tracks (single-task CTR, multitask, sequence) and
+emits a sorted leaderboard.
+
+Run as a module::
+
+    python -m benchmarks.benchmark --track single
+
+See ``benchmarks/README.md`` for full usage.
+"""
+
+import os as _os
+
+# DeepCTR targets the Keras 2 API. On TensorFlow >= 2.16 (which defaults to
+# Keras 3) the sequence/multitask layers break unless legacy Keras is used --
+# exactly as the library's own CI does (TF_USE_LEGACY_KERAS=1 + the `tf-keras`
+# package). Set it here, before any submodule imports TensorFlow, so every
+# entry point (CLI, tests, direct imports) is consistent. Users can override by
+# exporting the variable themselves.
+_os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
+
+__all__ = []

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -72,6 +72,7 @@ def run_single(args):
         hash_buckets=args.hash_buckets,
         test_size=args.test_size, seed=args.seed, max_rows=args.max_rows,
         download_url=args.download_url,
+        temporal_split=args.temporal_split, time_col=args.time_col,
     )
     names = select(list(SINGLE_TASK_MODELS), args.models, args.exclude)
     if args.quick:
@@ -213,6 +214,11 @@ def build_parser():
     p.add_argument("--batch-size", type=int, default=256)
     p.add_argument("--val-split", type=float, default=0.2)
     p.add_argument("--test-size", type=float, default=0.2)
+    p.add_argument("--temporal-split", action="store_true",
+                   help="single-task: chronological hold-out (most recent test_size as test) "
+                        "instead of a random split; use for time-ordered logs to avoid leakage")
+    p.add_argument("--time-col", default=None,
+                   help="single-task --temporal-split: column to sort by before the positional split")
     p.add_argument("--embedding-dim", type=int, default=8)
     p.add_argument("--seed", type=int, default=2020)
     p.add_argument("--fit-verbose", type=int, default=0, help="passed to model.fit(verbose=...)")

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,0 +1,238 @@
+"""DeepCTR benchmark CLI.
+
+Train and compare DeepCTR models end-to-end and emit a sorted leaderboard.
+
+Examples
+--------
+    python -m benchmarks.benchmark --track single                 # bundled Criteo, all single-task models
+    python -m benchmarks.benchmark --track single --download      # fetch Criteo DAC ~100k, then benchmark
+    python -m benchmarks.benchmark --track single --data-path train.txt --hash --epochs 5
+    python -m benchmarks.benchmark --track multitask
+    python -m benchmarks.benchmark --track sequence --seq-source synthetic
+    python -m benchmarks.benchmark --track all --quick
+"""
+from __future__ import absolute_import, division, print_function
+
+import argparse
+import os
+import time
+
+from .common import (ModelResult, _fmt, print_leaderboard, reset_session, set_seeds,
+                     sort_results, write_results)
+from .datasets import load_census, load_criteo, make_sequence_datasets
+from .metrics import compute_metrics
+from .registry import (MULTITASK_MODELS, SEQUENCE_MODELS, SINGLE_TASK_MODELS, SkipModel, select)
+
+_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_RESULTS_DIR = os.path.join(_PKG_DIR, "results")
+
+
+def _short(exc):
+    s = str(exc).strip().replace("\n", " ")
+    return (s[:160] + "...") if len(s) > 160 else s
+
+
+def _evaluate(name, seed, build_and_train):
+    """Run one model's ``build_and_train() -> (metrics, params, seconds)`` with
+    a fresh session, fixed seed, and error isolation."""
+    reset_session()
+    set_seeds(seed)
+    try:
+        metrics, params, secs = build_and_train()
+        return ModelResult(name, "ok", metrics, params, secs)
+    except SkipModel as exc:
+        return ModelResult(name, "skipped", note=str(exc))
+    except Exception as exc:  # one bad model must never abort the sweep
+        return ModelResult(name, "failed", note=_short(exc))
+
+
+def _print_progress(track, r):
+    bits = " ".join("%s=%s" % (k, _fmt(v)) for k, v in r.metrics.items())
+    extra = "" if r.train_seconds is None else " (%.1fs)" % r.train_seconds
+    note = "" if not r.note else " :: %s" % r.note
+    print("[%s] %-12s %-7s %s%s%s" % (track, r.model, r.status, bits, extra, note))
+
+
+def _finish(results, primary_metric, track, dataset, out_dir, title):
+    results = sort_results(results, primary_metric)
+    print_leaderboard(results, primary_metric, title)
+    csv_path, md_path = write_results(results, out_dir, track, dataset, primary_metric)
+    print("wrote %s" % csv_path)
+    print("wrote %s" % md_path)
+    return results
+
+
+# --------------------------------------------------------------------------- #
+# Track runners.
+# --------------------------------------------------------------------------- #
+def run_single(args):
+    data = load_criteo(
+        source="download" if args.download else args.source,
+        data_path=args.data_path, embedding_dim=args.embedding_dim, use_hash=args.hash,
+        hash_buckets=args.hash_buckets,
+        test_size=args.test_size, seed=args.seed, max_rows=args.max_rows,
+        download_url=args.download_url,
+    )
+    names = select(list(SINGLE_TASK_MODELS), args.models, args.exclude)
+    if args.quick:
+        names = names[:2]
+
+    loss = "binary_crossentropy" if data.task == "binary" else "mse"
+    compile_metric = ["binary_crossentropy"] if data.task == "binary" else ["mse"]
+    primary = "AUC" if data.task == "binary" else "RMSE"
+
+    print("== single-task track | dataset=%s | %d models | task=%s ==" % (data.name, len(names), data.task))
+    results = []
+    for name in names:
+        def build_and_train(name=name):
+            model = SINGLE_TASK_MODELS[name](data.linear_feature_columns, data.dnn_feature_columns, data.task)
+            model.compile("adam", loss, metrics=compile_metric)
+            t0 = time.time()
+            model.fit(data.train_input, data.train_y, batch_size=args.batch_size,
+                      epochs=args.epochs, verbose=args.fit_verbose, validation_split=args.val_split)
+            secs = time.time() - t0
+            pred = model.predict(data.test_input, batch_size=args.batch_size)
+            return compute_metrics(data.task, data.test_y, pred), model.count_params(), secs
+
+        r = _evaluate(name, args.seed, build_and_train)
+        _print_progress("single", r)
+        results.append(r)
+
+    return _finish(results, primary, "single", data.name, args.output_dir,
+                   "Single-task CTR leaderboard (%s)" % data.name)
+
+
+def run_multitask(args):
+    data = load_census(data_path=args.data_path, embedding_dim=args.embedding_dim,
+                       test_size=args.test_size, seed=args.seed)
+    names = select(list(MULTITASK_MODELS), args.models, args.exclude)
+    if args.quick:
+        names = names[:2]
+
+    n_tasks = len(data.task_types)
+    print("== multitask track | dataset=%s | %d models | tasks=%s ==" % (data.name, len(names), data.task_names))
+    results = []
+    for name in names:
+        def build_and_train(name=name):
+            model = MULTITASK_MODELS[name](data.dnn_feature_columns, data.task_types, data.task_names)
+            # No compile-time metrics: a flat list is applied to every output and
+            # collides on names; we compute AUC/LogLoss from predictions anyway.
+            model.compile("adam", loss=["binary_crossentropy"] * n_tasks)
+            t0 = time.time()
+            model.fit(data.train_input, data.train_y, batch_size=args.batch_size,
+                      epochs=args.epochs, verbose=args.fit_verbose, validation_split=args.val_split)
+            secs = time.time() - t0
+            preds = model.predict(data.test_input, batch_size=args.batch_size)
+            if not isinstance(preds, (list, tuple)):
+                preds = [preds]
+            merged, aucs = {}, []
+            for i, tname in enumerate(data.task_names):
+                m = compute_metrics("binary", data.test_y[i], preds[i])
+                for k, v in m.items():
+                    merged["%s_%s" % (tname, k)] = v
+                if m["AUC"] == m["AUC"]:  # not NaN
+                    aucs.append(m["AUC"])
+            merged["mean_AUC"] = round(sum(aucs) / len(aucs), 4) if aucs else float("nan")
+            return merged, model.count_params(), secs
+
+        r = _evaluate(name, args.seed, build_and_train)
+        _print_progress("multitask", r)
+        results.append(r)
+
+    return _finish(results, "mean_AUC", "multitask", data.name, args.output_dir,
+                   "Multitask leaderboard (%s)" % data.name)
+
+
+def run_sequence(args):
+    n_samples = 400 if args.quick else args.n_samples
+    din_data, dsin_data = make_sequence_datasets(
+        source=args.seq_source, n_samples=n_samples, max_hist=args.sess_max_count * args.sess_len,
+        sess_max_count=args.sess_max_count, sess_len=args.sess_len, embedding_dim=args.embedding_dim,
+        test_size=args.test_size, seed=args.seed, data_path=args.data_path,
+    )
+    dataset_name = din_data.name
+    names = select(list(SEQUENCE_MODELS), args.models, args.exclude)
+    if args.quick:
+        names = names[:2]
+
+    print("== sequence track | dataset=%s | %d models ==" % (dataset_name, len(names)))
+    results = []
+    for name in names:
+        spec = SEQUENCE_MODELS[name]
+        data = din_data if spec["view"] == "din" else dsin_data
+
+        def build_and_train(spec=spec, data=data):
+            model = spec["build"](data, "binary")
+            model.compile("adam", "binary_crossentropy", metrics=["binary_crossentropy"])
+            t0 = time.time()
+            model.fit(data.train_input, data.train_y, batch_size=args.batch_size,
+                      epochs=args.epochs, verbose=args.fit_verbose, validation_split=args.val_split)
+            secs = time.time() - t0
+            pred = model.predict(data.test_input, batch_size=args.batch_size)
+            return compute_metrics("binary", data.test_y, pred), model.count_params(), secs
+
+        r = _evaluate(name, args.seed, build_and_train)
+        _print_progress("sequence", r)
+        results.append(r)
+
+    return _finish(results, "AUC", "sequence", dataset_name, args.output_dir,
+                   "Sequence leaderboard (%s)" % dataset_name)
+
+
+# --------------------------------------------------------------------------- #
+# CLI.
+# --------------------------------------------------------------------------- #
+def _csv_list(value):
+    return [v.strip() for v in value.split(",") if v.strip()] if value else None
+
+
+def build_parser():
+    from .datasets.criteo import DEFAULT_DAC_URL
+
+    p = argparse.ArgumentParser(description="DeepCTR model evaluation / benchmark pipeline")
+    p.add_argument("--track", choices=["single", "multitask", "sequence", "all"], default="single")
+    # data sources
+    p.add_argument("--source", choices=["bundled", "download"], default="bundled",
+                   help="single-task: bundled sample (default) or download Criteo DAC")
+    p.add_argument("--download", action="store_true", help="shortcut for --source download")
+    p.add_argument("--download-url", default=DEFAULT_DAC_URL)
+    p.add_argument("--data-path", default=None, help="path to a full Criteo / Census / MovieLens file")
+    p.add_argument("--hash", action="store_true", help="single-task: hash sparse features (no LabelEncoder)")
+    p.add_argument("--hash-buckets", type=int, default=1000,
+                   help="single-task --hash: bucket count per sparse feature (raise for high-cardinality data)")
+    p.add_argument("--max-rows", type=int, default=None, help="subsample the first N rows (large files)")
+    p.add_argument("--seq-source", choices=["synthetic", "movielens"], default="synthetic")
+    p.add_argument("--n-samples", type=int, default=2000, help="synthetic sequence sample count")
+    p.add_argument("--sess-max-count", type=int, default=3, help="DSIN sessions per user")
+    p.add_argument("--sess-len", type=int, default=4, help="DSIN session length")
+    # model selection
+    p.add_argument("--models", type=_csv_list, default=None, help="comma-separated subset to run")
+    p.add_argument("--exclude", type=_csv_list, default=None, help="comma-separated models to skip")
+    # training
+    p.add_argument("--epochs", type=int, default=5)
+    p.add_argument("--batch-size", type=int, default=256)
+    p.add_argument("--val-split", type=float, default=0.2)
+    p.add_argument("--test-size", type=float, default=0.2)
+    p.add_argument("--embedding-dim", type=int, default=8)
+    p.add_argument("--seed", type=int, default=2020)
+    p.add_argument("--fit-verbose", type=int, default=0, help="passed to model.fit(verbose=...)")
+    p.add_argument("--quick", action="store_true", help="fast self-test: 1 epoch, 2 models/track, small data")
+    p.add_argument("--output-dir", default=DEFAULT_RESULTS_DIR)
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if args.quick:
+        args.epochs = 1
+
+    runners = {"single": run_single, "multitask": run_multitask, "sequence": run_sequence}
+    if args.track == "all":
+        for track in ["single", "multitask", "sequence"]:
+            runners[track](args)
+    else:
+        runners[args.track](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -1,0 +1,218 @@
+"""Shared utilities for the DeepCTR benchmark suite: reproducibility helpers,
+the data/result containers passed between modules, and leaderboard writers.
+"""
+from __future__ import absolute_import, division, print_function
+
+import csv
+import os
+import random
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from .metrics import HIGHER_IS_BETTER
+
+
+# --------------------------------------------------------------------------- #
+# Containers passed from dataset loaders to the track runners.
+# --------------------------------------------------------------------------- #
+@dataclass
+class SingleTaskData:
+    name: str
+    task: str  # 'binary' or 'regression'
+    linear_feature_columns: list
+    dnn_feature_columns: list
+    feature_names: list
+    train_input: dict
+    train_y: np.ndarray
+    test_input: dict
+    test_y: np.ndarray
+    target: str = "label"
+
+
+@dataclass
+class MultiTaskData:
+    name: str
+    dnn_feature_columns: list
+    feature_names: list
+    train_input: dict
+    train_y: List[np.ndarray]
+    test_input: dict
+    test_y: List[np.ndarray]
+    task_types: tuple
+    task_names: tuple
+
+
+@dataclass
+class SequenceData:
+    name: str
+    feature_columns: list
+    behavior_feature_list: list
+    train_input: dict
+    train_y: np.ndarray
+    test_input: dict
+    test_y: np.ndarray
+    # >0 only for DSIN-style sessionized data; the number of sessions.
+    sess_max_count: int = 0
+
+
+@dataclass
+class ModelResult:
+    model: str
+    status: str  # 'ok' | 'failed' | 'skipped'
+    metrics: Dict[str, float] = field(default_factory=dict)
+    params: Optional[int] = None
+    train_seconds: Optional[float] = None
+    note: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Reproducibility.
+# --------------------------------------------------------------------------- #
+def set_seeds(seed=2020):
+    """Seed python, numpy and TensorFlow RNGs."""
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    try:
+        import tensorflow as tf
+
+        tf.random.set_seed(seed)
+    except Exception:  # pragma: no cover - tf always present in practice
+        pass
+
+
+def reset_session():
+    """Clear the Keras backend between models so a 20+ model sweep doesn't
+    accumulate graph state / leak memory."""
+    try:
+        import tensorflow as tf
+
+        tf.keras.backend.clear_session()
+    except Exception:  # pragma: no cover
+        pass
+
+
+def split_dict_xy(x, y, test_size=0.2, seed=2020):
+    """Index-based train/test split for a dict-of-arrays input and a 1-D ``y``.
+
+    Used by the sequence track, whose features are built directly as numpy
+    arrays rather than a DataFrame. Every value in ``x`` has length ``len(y)``.
+    """
+    y = np.asarray(y)
+    n = len(y)
+    rng = np.random.RandomState(seed)
+    idx = np.arange(n)
+    rng.shuffle(idx)
+    cut = max(1, int(round(n * (1 - test_size))))
+    tr, te = idx[:cut], idx[cut:]
+    if len(te) == 0:  # degenerate tiny-sample case: reuse train as test
+        te = tr
+    train_x = {k: np.asarray(v)[tr] for k, v in x.items()}
+    test_x = {k: np.asarray(v)[te] for k, v in x.items()}
+    return train_x, y[tr], test_x, y[te]
+
+
+# --------------------------------------------------------------------------- #
+# Leaderboard rendering / persistence.
+# --------------------------------------------------------------------------- #
+def _metric_keys(results):
+    keys = []
+    for r in results:
+        for k in r.metrics:
+            if k not in keys:
+                keys.append(k)
+    return keys
+
+
+def _is_nan(v):
+    return isinstance(v, float) and np.isnan(v)
+
+
+def sort_results(results, primary_metric):
+    """Return results with ``status=='ok'`` first, ranked by ``primary_metric``
+    (direction from HIGHER_IS_BETTER), then skipped/failed rows."""
+    higher = HIGHER_IS_BETTER.get(primary_metric, True)
+
+    def key(r):
+        v = r.metrics.get(primary_metric)
+        if v is None or _is_nan(v):
+            return (1, 0.0)  # undefined metric -> bottom of the ok group
+        return (0, -v if higher else v)
+
+    ok = sorted([r for r in results if r.status == "ok"], key=key)
+    rest = [r for r in results if r.status != "ok"]
+    return ok + rest
+
+
+def _fmt(v):
+    if v is None:
+        return ""
+    if _is_nan(v):
+        return "nan"
+    if isinstance(v, float):
+        return "%.4f" % v
+    return str(v)
+
+
+def format_markdown(results, primary_metric):
+    metric_keys = _metric_keys(results)
+    headers = ["Rank", "Model", "Status"] + metric_keys + ["Params", "Train(s)", "Note"]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(["---"] * len(headers)) + " |",
+    ]
+    rank = 0
+    for r in results:
+        if r.status == "ok":
+            rank += 1
+            rank_s = str(rank)
+        else:
+            rank_s = "-"
+        row = [rank_s, r.model, r.status]
+        row += [_fmt(r.metrics.get(k)) for k in metric_keys]
+        row.append("" if r.params is None else "{:,}".format(r.params))
+        row.append("" if r.train_seconds is None else "%.1f" % r.train_seconds)
+        row.append(r.note or "")
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines)
+
+
+def write_results(results, out_dir, track, dataset, primary_metric):
+    """Write ``<track>_<dataset>.csv`` and ``.md`` to ``out_dir``; return paths."""
+    os.makedirs(out_dir, exist_ok=True)
+    base = "%s_%s" % (track, dataset)
+    metric_keys = _metric_keys(results)
+
+    csv_path = os.path.join(out_dir, base + ".csv")
+    with open(csv_path, "w", newline="") as f:
+        fieldnames = ["model", "status"] + metric_keys + ["params", "train_seconds", "note"]
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for r in results:
+            row = {
+                "model": r.model,
+                "status": r.status,
+                "params": r.params,
+                "train_seconds": None if r.train_seconds is None else round(r.train_seconds, 2),
+                "note": r.note,
+            }
+            for k in metric_keys:
+                row[k] = r.metrics.get(k)
+            w.writerow(row)
+
+    md_path = os.path.join(out_dir, base + ".md")
+    with open(md_path, "w") as f:
+        f.write("# DeepCTR benchmark - %s track on `%s`\n\n" % (track, dataset))
+        f.write(format_markdown(results, primary_metric) + "\n")
+
+    return csv_path, md_path
+
+
+def print_leaderboard(results, primary_metric, title):
+    print("\n" + "=" * 70)
+    print(title)
+    print("=" * 70)
+    print(format_markdown(results, primary_metric))
+    print("")

--- a/benchmarks/datasets/__init__.py
+++ b/benchmarks/datasets/__init__.py
@@ -1,0 +1,11 @@
+"""Dataset loaders for the benchmark suite.
+
+Each loader returns one of the typed containers from ``benchmarks.common``
+(``SingleTaskData`` / ``MultiTaskData`` / ``SequenceData``) with feature
+columns and ready-to-fit train/test inputs already built.
+"""
+from .census import load_census
+from .criteo import load_criteo
+from .sequence import make_sequence_datasets
+
+__all__ = ["load_criteo", "load_census", "make_sequence_datasets"]

--- a/benchmarks/datasets/census.py
+++ b/benchmarks/datasets/census.py
@@ -45,9 +45,35 @@ TASK_TYPES = ("binary", "binary")
 
 
 def load_census(data_path=None, embedding_dim=4, test_size=0.2, seed=2020):
-    """Load and preprocess Census-Income into a :class:`MultiTaskData`."""
-    path = data_path or os.path.join(EXAMPLES_DIR, "census-income.sample")
-    data = pd.read_csv(path, header=None, names=COLUMN_NAMES)
+    """Load and preprocess Census-Income into a :class:`MultiTaskData`.
+
+    The UCI Census-Income (KDD) distribution ships an *official* train/test
+    partition: ``census-income.data`` (train) and ``census-income.test`` (test).
+    When ``data_path`` points at the ``.data`` file and its sibling ``.test``
+    exists, that official split is used instead of a random one -- this is the
+    canonical evaluation for the dataset and avoids reshuffling the two together.
+    Encoders are still fit on the union so categories that appear only in the
+    test partition don't crash the run. The bundled sample has no ``.test``
+    sibling and falls back to a random split.
+    """
+    train_path = data_path or os.path.join(EXAMPLES_DIR, "census-income.sample")
+
+    official_test = None
+    if data_path and data_path.endswith(".data"):
+        sibling = data_path[: -len(".data")] + ".test"
+        if os.path.exists(sibling):
+            official_test = sibling
+
+    if official_test:
+        train_df = pd.read_csv(train_path, header=None, names=COLUMN_NAMES)
+        test_df = pd.read_csv(official_test, header=None, names=COLUMN_NAMES)
+        n_train = len(train_df)
+        data = pd.concat([train_df, test_df], ignore_index=True)
+        print("[census] using official train/test split (%d train + %d test rows)"
+              % (n_train, len(test_df)))
+    else:
+        data = pd.read_csv(train_path, header=None, names=COLUMN_NAMES)
+        n_train = None
 
     data["label_income"] = data["income_50k"].map({" - 50000.": 0, " 50000+.": 1})
     data["label_marital"] = data["marital_stat"].apply(lambda x: 1 if x == " Never married" else 0)
@@ -68,7 +94,10 @@ def load_census(data_path=None, embedding_dim=4, test_size=0.2, seed=2020):
     )
     feature_names = get_feature_names(feature_columns)
 
-    train, test = train_test_split(data, test_size=test_size, random_state=seed)
+    if n_train is not None:
+        train, test = data.iloc[:n_train], data.iloc[n_train:]
+    else:
+        train, test = train_test_split(data, test_size=test_size, random_state=seed)
     train_input = {n: train[n].values for n in feature_names}
     test_input = {n: test[n].values for n in feature_names}
 

--- a/benchmarks/datasets/census.py
+++ b/benchmarks/datasets/census.py
@@ -1,0 +1,85 @@
+"""Census-Income loader for the multitask track (ported from
+``examples/run_mtl.py``).
+
+Two binary tasks are derived: ``label_income`` (>50k) and ``label_marital``
+(never-married). DNN-only feature columns (multitask models take no linear
+part). ``data_path`` accepts the full UCI Census-Income KDD ``.data`` file,
+which shares the bundled sample's headerless, comma-separated format.
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder, MinMaxScaler
+
+from deepctr.feature_column import DenseFeat, SparseFeat, get_feature_names
+
+from ..common import MultiTaskData
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+EXAMPLES_DIR = os.path.join(os.path.dirname(os.path.dirname(_HERE)), "examples")
+
+COLUMN_NAMES = [
+    "age", "class_worker", "det_ind_code", "det_occ_code", "education", "wage_per_hour", "hs_college",
+    "marital_stat", "major_ind_code", "major_occ_code", "race", "hisp_origin", "sex", "union_member",
+    "unemp_reason", "full_or_part_emp", "capital_gains", "capital_losses", "stock_dividends",
+    "tax_filer_stat", "region_prev_res", "state_prev_res", "det_hh_fam_stat", "det_hh_summ",
+    "instance_weight", "mig_chg_msa", "mig_chg_reg", "mig_move_reg", "mig_same", "mig_prev_sunbelt",
+    "num_emp", "fam_under_18", "country_father", "country_mother", "country_self", "citizenship",
+    "own_or_self", "vet_question", "vet_benefits", "weeks_worked", "year", "income_50k",
+]
+
+SPARSE_FEATURES = [
+    "class_worker", "det_ind_code", "det_occ_code", "education", "hs_college", "major_ind_code",
+    "major_occ_code", "race", "hisp_origin", "sex", "union_member", "unemp_reason",
+    "full_or_part_emp", "tax_filer_stat", "region_prev_res", "state_prev_res", "det_hh_fam_stat",
+    "det_hh_summ", "mig_chg_msa", "mig_chg_reg", "mig_move_reg", "mig_same", "mig_prev_sunbelt",
+    "fam_under_18", "country_father", "country_mother", "country_self", "citizenship",
+    "vet_question",
+]
+
+TASK_NAMES = ("label_income", "label_marital")
+TASK_TYPES = ("binary", "binary")
+
+
+def load_census(data_path=None, embedding_dim=4, test_size=0.2, seed=2020):
+    """Load and preprocess Census-Income into a :class:`MultiTaskData`."""
+    path = data_path or os.path.join(EXAMPLES_DIR, "census-income.sample")
+    data = pd.read_csv(path, header=None, names=COLUMN_NAMES)
+
+    data["label_income"] = data["income_50k"].map({" - 50000.": 0, " 50000+.": 1})
+    data["label_marital"] = data["marital_stat"].apply(lambda x: 1 if x == " Never married" else 0)
+    data.drop(labels=["income_50k", "marital_stat"], axis=1, inplace=True)
+
+    columns = data.columns.values.tolist()
+    dense_features = [c for c in columns if c not in SPARSE_FEATURES and c not in TASK_NAMES]
+
+    data[SPARSE_FEATURES] = data[SPARSE_FEATURES].fillna("-1")
+    data[dense_features] = data[dense_features].fillna(0)
+    data[dense_features] = MinMaxScaler((0, 1)).fit_transform(data[dense_features])
+    for feat in SPARSE_FEATURES:
+        data[feat] = LabelEncoder().fit_transform(data[feat])
+
+    feature_columns = (
+        [SparseFeat(feat, int(data[feat].max()) + 1, embedding_dim=embedding_dim) for feat in SPARSE_FEATURES]
+        + [DenseFeat(feat, 1) for feat in dense_features]
+    )
+    feature_names = get_feature_names(feature_columns)
+
+    train, test = train_test_split(data, test_size=test_size, random_state=seed)
+    train_input = {n: train[n].values for n in feature_names}
+    test_input = {n: test[n].values for n in feature_names}
+
+    return MultiTaskData(
+        name="census",
+        dnn_feature_columns=feature_columns,
+        feature_names=feature_names,
+        train_input=train_input,
+        train_y=[train[t].values.reshape(-1, 1) for t in TASK_NAMES],
+        test_input=test_input,
+        test_y=[test[t].values.reshape(-1, 1) for t in TASK_NAMES],
+        task_types=TASK_TYPES,
+        task_names=TASK_NAMES,
+    )

--- a/benchmarks/datasets/criteo.py
+++ b/benchmarks/datasets/criteo.py
@@ -1,0 +1,151 @@
+"""Criteo dataset loader for the single-task (binary CTR) track.
+
+Three sources, one preprocessing path (ported from
+``examples/run_classification_criteo.py`` and ``..._hash.py``):
+
+* ``bundled``  - the 200-row ``examples/criteo_sample.txt`` (offline, deterministic).
+* ``download`` - the Criteo "DAC" ~100k-row sample, fetched once into
+  ``benchmarks/data/``; falls back to the bundled sample if the network/URL fails.
+* ``data_path``- any full Criteo file (``train.txt`` / ``dac_sample.txt``: TSV,
+  no header, ``label`` + I1..I13 + C1..C26).
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import tarfile
+import urllib.request
+
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder, MinMaxScaler
+
+from deepctr.feature_column import DenseFeat, SparseFeat, get_feature_names
+
+from ..common import SingleTaskData
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+EXAMPLES_DIR = os.path.join(os.path.dirname(os.path.dirname(_HERE)), "examples")
+DATA_DIR = os.path.join(os.path.dirname(_HERE), "data")
+
+DENSE_FEATURES = ["I%d" % i for i in range(1, 14)]
+SPARSE_FEATURES = ["C%d" % i for i in range(1, 27)]
+COLUMNS = ["label"] + DENSE_FEATURES + SPARSE_FEATURES
+
+# Historical Criteo Labs mirror of the 100k-row DAC sample. May be offline; the
+# loader degrades gracefully to the bundled sample when it is.
+DEFAULT_DAC_URL = "https://s3-eu-west-1.amazonaws.com/criteo-labs/dac_sample.tar.gz"
+
+
+def _read_bundled():
+    return pd.read_csv(os.path.join(EXAMPLES_DIR, "criteo_sample.txt"))
+
+
+def _read_criteo_file(path):
+    """Read a Criteo file, auto-detecting separator and header."""
+    with open(path) as f:
+        first = f.readline()
+    sep = "\t" if "\t" in first else ","
+    if first.lower().startswith("label"):
+        return pd.read_csv(path, sep=sep)
+    return pd.read_csv(path, sep=sep, header=None, names=COLUMNS)
+
+
+def _print_manual_instructions(url):
+    print(
+        "[criteo] To benchmark on real data, download the Criteo DAC sample "
+        "manually and pass it via --data-path:\n"
+        "           curl -L -o dac_sample.tar.gz '%s'\n"
+        "           tar -xzf dac_sample.tar.gz   # -> dac_sample.txt\n"
+        "         (or point --data-path at any full Criteo train.txt)." % url
+    )
+
+
+def _download_dac_sample(url, dest_dir):
+    """Download + extract ``dac_sample.txt`` into ``dest_dir``; return its path.
+
+    Cached: a second call reuses the extracted file. Raises on failure (the
+    caller handles fallback).
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    target_txt = os.path.join(dest_dir, "dac_sample.txt")
+    if os.path.exists(target_txt):
+        return target_txt
+
+    tar_path = os.path.join(dest_dir, "dac_sample.tar.gz")
+    print("[criteo] downloading DAC sample from %s ..." % url)
+    urllib.request.urlretrieve(url, tar_path)
+    with tarfile.open(tar_path) as tar:
+        member = next(m for m in tar.getmembers() if m.name.endswith("dac_sample.txt"))
+        member.name = os.path.basename(member.name)  # strip any leading path
+        tar.extract(member, dest_dir)
+    return target_txt
+
+
+def load_criteo(source="bundled", data_path=None, embedding_dim=8, use_hash=False,
+                hash_buckets=1000, test_size=0.2, seed=2020, max_rows=None,
+                download_url=DEFAULT_DAC_URL):
+    """Load and preprocess Criteo into a :class:`SingleTaskData` (task='binary')."""
+    if data_path is not None:
+        df = _read_criteo_file(data_path)
+        name = "criteo_custom"
+    elif source == "download":
+        path = None
+        try:
+            path = _download_dac_sample(download_url, DATA_DIR)
+        except Exception as exc:  # network down, URL moved, bad archive, ...
+            print("[criteo] download failed (%s); using bundled sample instead." % exc)
+            _print_manual_instructions(download_url)
+        if path:
+            df = _read_criteo_file(path)
+            name = "criteo_dac100k"
+        else:
+            df, name = _read_bundled(), "criteo_sample"
+    else:
+        df, name = _read_bundled(), "criteo_sample"
+
+    if max_rows:
+        df = df.head(int(max_rows)).copy()
+
+    df[SPARSE_FEATURES] = df[SPARSE_FEATURES].fillna("-1")
+    df[DENSE_FEATURES] = df[DENSE_FEATURES].fillna(0)
+
+    if use_hash:
+        # Hash the raw string values inside the model (no label encoding).
+        for feat in SPARSE_FEATURES:
+            df[feat] = df[feat].astype(str)
+        sparse_cols = [
+            SparseFeat(feat, hash_buckets, embedding_dim=embedding_dim, use_hash=True, dtype="string")
+            for feat in SPARSE_FEATURES
+        ]
+    else:
+        for feat in SPARSE_FEATURES:
+            df[feat] = LabelEncoder().fit_transform(df[feat])
+        sparse_cols = [
+            SparseFeat(feat, vocabulary_size=int(df[feat].max()) + 1, embedding_dim=embedding_dim)
+            for feat in SPARSE_FEATURES
+        ]
+
+    df[DENSE_FEATURES] = MinMaxScaler((0, 1)).fit_transform(df[DENSE_FEATURES])
+    dense_cols = [DenseFeat(feat, 1) for feat in DENSE_FEATURES]
+
+    feature_columns = sparse_cols + dense_cols
+    feature_names = get_feature_names(feature_columns)
+
+    train, test = train_test_split(df, test_size=test_size, random_state=seed)
+    train_input = {n: train[n].values for n in feature_names}
+    test_input = {n: test[n].values for n in feature_names}
+
+    return SingleTaskData(
+        name=name,
+        task="binary",
+        linear_feature_columns=feature_columns,
+        dnn_feature_columns=feature_columns,
+        feature_names=feature_names,
+        train_input=train_input,
+        # 2-D targets: DeepCTR's PredictionLayer emits shape (None, 1) and
+        # Keras 3 (TF>=2.16) requires target rank to match output rank.
+        train_y=train["label"].values.reshape(-1, 1),
+        test_input=test_input,
+        test_y=test["label"].values.reshape(-1, 1),
+        target="label",
+    )

--- a/benchmarks/datasets/criteo.py
+++ b/benchmarks/datasets/criteo.py
@@ -83,8 +83,16 @@ def _download_dac_sample(url, dest_dir):
 
 def load_criteo(source="bundled", data_path=None, embedding_dim=8, use_hash=False,
                 hash_buckets=1000, test_size=0.2, seed=2020, max_rows=None,
-                download_url=DEFAULT_DAC_URL):
-    """Load and preprocess Criteo into a :class:`SingleTaskData` (task='binary')."""
+                download_url=DEFAULT_DAC_URL, temporal_split=False, time_col=None):
+    """Load and preprocess Criteo into a :class:`SingleTaskData` (task='binary').
+
+    By default the train/test split is random (the Kaggle DAC / Criteo_x1 data
+    is anonymised and shuffled, with no timestamp, so this is leakage-free and
+    standard). For logs that *do* carry time, pass ``temporal_split=True`` to
+    hold out the most recent ``test_size`` fraction instead: rows are sorted by
+    ``time_col`` when given, otherwise the file's existing order is trusted, and
+    the tail becomes the test set -- so no future row can leak into training.
+    """
     if data_path is not None:
         df = _read_criteo_file(data_path)
         name = "criteo_custom"
@@ -131,7 +139,19 @@ def load_criteo(source="bundled", data_path=None, embedding_dim=8, use_hash=Fals
     feature_columns = sparse_cols + dense_cols
     feature_names = get_feature_names(feature_columns)
 
-    train, test = train_test_split(df, test_size=test_size, random_state=seed)
+    if temporal_split:
+        # Chronological hold-out: the most recent rows become the test set so no
+        # future information leaks into training. Sort by time_col when present;
+        # otherwise assume the file is already in chronological order.
+        if time_col and time_col in df.columns:
+            df = df.sort_values(time_col, kind="mergesort")  # stable
+        elif time_col:
+            print("[criteo] --time-col %r not found; assuming the file is already "
+                  "in chronological order." % time_col)
+        cut = max(1, int(round(len(df) * (1 - test_size))))
+        train, test = df.iloc[:cut], df.iloc[cut:]
+    else:
+        train, test = train_test_split(df, test_size=test_size, random_state=seed)
     train_input = {n: train[n].values for n in feature_names}
     test_input = {n: test[n].values for n in feature_names}
 

--- a/benchmarks/datasets/criteo.py
+++ b/benchmarks/datasets/criteo.py
@@ -31,9 +31,12 @@ DENSE_FEATURES = ["I%d" % i for i in range(1, 14)]
 SPARSE_FEATURES = ["C%d" % i for i in range(1, 27)]
 COLUMNS = ["label"] + DENSE_FEATURES + SPARSE_FEATURES
 
-# Historical Criteo Labs mirror of the 100k-row DAC sample. May be offline; the
-# loader degrades gracefully to the bundled sample when it is.
-DEFAULT_DAC_URL = "https://s3-eu-west-1.amazonaws.com/criteo-labs/dac_sample.tar.gz"
+# Criteo's historical public DAC-sample mirror (criteo-labs S3) is offline, and
+# there is no stable drop-in auto-download anymore (the data now lives as large
+# multi-file datasets on Hugging Face / Criteo AI Lab). So there is no default
+# auto-download: use --data-path for real data, or pass your own tar.gz mirror
+# via --download-url. The loader degrades gracefully to the bundled sample.
+DEFAULT_DAC_URL = None
 
 
 def _read_bundled():
@@ -50,13 +53,17 @@ def _read_criteo_file(path):
     return pd.read_csv(path, sep=sep, header=None, names=COLUMNS)
 
 
-def _print_manual_instructions(url):
+def _print_manual_instructions():
     print(
-        "[criteo] To benchmark on real data, download the Criteo DAC sample "
-        "manually and pass it via --data-path:\n"
-        "           curl -L -o dac_sample.tar.gz '%s'\n"
-        "           tar -xzf dac_sample.tar.gz   # -> dac_sample.txt\n"
-        "         (or point --data-path at any full Criteo train.txt)." % url
+        "[criteo] No public auto-download is available (Criteo's DAC-sample mirror "
+        "is offline).\n"
+        "         For a real benchmark, fetch a Criteo dataset and pass it via "
+        "--data-path, e.g.:\n"
+        "           - Criteo_x1 split:  https://huggingface.co/datasets/reczoo/Criteo_x1\n"
+        "           - Full click logs:  https://huggingface.co/datasets/criteo/CriteoClickLogs\n"
+        "           - Criteo AI Lab:    https://ailab.criteo.com/ressources/\n"
+        "         then:  python -m benchmarks.benchmark --track single --data-path <file.csv>\n"
+        "         (or pass a working tar.gz mirror via --download-url)."
     )
 
 
@@ -98,11 +105,16 @@ def load_criteo(source="bundled", data_path=None, embedding_dim=8, use_hash=Fals
         name = "criteo_custom"
     elif source == "download":
         path = None
-        try:
-            path = _download_dac_sample(download_url, DATA_DIR)
-        except Exception as exc:  # network down, URL moved, bad archive, ...
-            print("[criteo] download failed (%s); using bundled sample instead." % exc)
-            _print_manual_instructions(download_url)
+        if download_url:
+            try:
+                path = _download_dac_sample(download_url, DATA_DIR)
+            except Exception as exc:  # network down, URL moved, bad archive, ...
+                print("[criteo] download failed (%s); using bundled sample instead." % exc)
+                _print_manual_instructions()
+        else:
+            print("[criteo] --source download requested but no download URL is "
+                  "configured (the historical DAC-sample mirror is offline).")
+            _print_manual_instructions()
         if path:
             df = _read_criteo_file(path)
             name = "criteo_dac100k"

--- a/benchmarks/datasets/sequence.py
+++ b/benchmarks/datasets/sequence.py
@@ -1,0 +1,212 @@
+"""Sequence-track data for DIN / DIEN / DSIN / BST.
+
+A single behavior generator produces per-sample ``(user, gender, target item,
+target cate, pay_score, history[(item, cate)...], label)`` tuples; two
+formatters turn those into the exact feature layouts the models expect:
+
+* ``_to_din_data``  -> ``hist_item_id`` / ``hist_cate_id`` + ``seq_length``
+  (DIN, BST, DIEN), behavior list ``["item_id", "cate_id"]``.
+* ``_to_dsin_data`` -> ``sess_k_item`` / ``sess_k_cate_id`` + ``sess_length``
+  (DSIN), behavior list ``["item", "cate_id"]``.
+
+Two sources:
+
+* ``synthetic`` (default): deterministic generator with an *injected* learnable
+  signal (label depends on user-cate preference and whether the target item is
+  in the history), so AUC is meaningfully > 0.5 and models are comparable.
+* ``movielens``: real sequences built from a MovieLens file (per user, sorted by
+  timestamp, target = current movie, history = prior movies, label = rating>=4,
+  cate = first genre). Tiny on the bundled 200-row sample; real on MovieLens-1M
+  via ``data_path``.
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import numpy as np
+
+from deepctr.feature_column import DenseFeat, SparseFeat, VarLenSparseFeat, get_feature_names
+
+from ..common import SequenceData, split_dict_xy
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+EXAMPLES_DIR = os.path.join(os.path.dirname(os.path.dirname(_HERE)), "examples")
+
+
+# --------------------------------------------------------------------------- #
+# Behavior generators -> parallel lists + (n_users, n_items, n_cates).
+# --------------------------------------------------------------------------- #
+def _generate_synthetic(n_samples, n_users, n_items, n_cates, max_hist, seed):
+    rng = np.random.RandomState(seed)
+    item2cate = rng.randint(1, n_cates + 1, size=n_items + 1)
+    item2cate[0] = 0  # 0 is the padding/mask id
+    pref = rng.rand(n_users, n_cates + 1)  # latent user x cate preference
+    fav_cate = pref.argmax(axis=1)  # each user's most-preferred category
+
+    users, genders, items, cates, scores, histories, ys = [], [], [], [], [], [], []
+    for _ in range(n_samples):
+        u = int(rng.randint(0, n_users))
+        g = int(rng.randint(0, 2))
+        length = int(rng.randint(1, max_hist + 1))
+        hist_items = rng.randint(1, n_items + 1, size=length)
+        hist = [(int(it), int(item2cate[it])) for it in hist_items]
+        # Half the time the candidate is drawn from the user's own history, so
+        # "is the target in the behavior sequence" is a strong, balanced signal
+        # that attention-based models are designed to capture.
+        if rng.rand() < 0.5:
+            tgt = int(rng.choice(hist_items))
+        else:
+            tgt = int(rng.randint(1, n_items + 1))
+        tcate = int(item2cate[tgt])
+        in_hist = 1.0 if tgt in hist_items else 0.0
+        logit = -1.2 + 2.6 * in_hist + 1.3 * (tcate == fav_cate[u]) + 0.2 * rng.randn()
+        p = 1.0 / (1.0 + np.exp(-logit))
+        users.append(u)
+        genders.append(g)
+        items.append(tgt)
+        cates.append(tcate)
+        scores.append(float(rng.rand()))
+        histories.append(hist)
+        ys.append(int(rng.rand() < p))
+    return users, genders, items, cates, scores, histories, ys, (n_users, n_items, n_cates)
+
+
+def _generate_movielens(path, max_hist):
+    import pandas as pd
+    from sklearn.preprocessing import LabelEncoder
+
+    df = pd.read_csv(path)
+    df = df.sort_values(["user_id", "timestamp"])
+    df["movie_idx"] = LabelEncoder().fit_transform(df["movie_id"]) + 1  # 0 = mask
+    df["cate"] = LabelEncoder().fit_transform(df["genres"].apply(lambda g: str(g).split("|")[0])) + 1
+    df["user_idx"] = LabelEncoder().fit_transform(df["user_id"])
+    df["gender_idx"] = (df["gender"] == "M").astype(int)
+
+    n_users = int(df["user_idx"].max()) + 1
+    n_items = int(df["movie_idx"].max())
+    n_cates = int(df["cate"].max())
+
+    users, genders, items, cates, scores, histories, ys = [], [], [], [], [], [], []
+    for _, grp in df.groupby("user_idx"):
+        seq = list(zip(grp["movie_idx"], grp["cate"], grp["rating"], grp["gender_idx"], grp["user_idx"]))
+        for i in range(1, len(seq)):
+            it, ct, rt, gd, u = seq[i]
+            hist = [(int(a), int(b)) for a, b, _, _, _ in seq[max(0, i - max_hist):i]]
+            if not hist:
+                continue
+            users.append(int(u))
+            genders.append(int(gd))
+            items.append(int(it))
+            cates.append(int(ct))
+            scores.append(0.0)
+            histories.append(hist)
+            ys.append(int(rt >= 4))
+    return users, genders, items, cates, scores, histories, ys, (n_users, n_items, n_cates)
+
+
+# --------------------------------------------------------------------------- #
+# Formatters -> SequenceData.
+# --------------------------------------------------------------------------- #
+def _to_din_data(samples, maxlen, embedding_dim, test_size, seed, name):
+    users, genders, items, cates, scores, histories, ys, (n_users, n_items, n_cates) = samples
+    n = len(ys)
+    hist_item = np.zeros((n, maxlen), dtype="int64")
+    hist_cate = np.zeros((n, maxlen), dtype="int64")
+    seq_length = np.zeros((n,), dtype="int64")
+    for i, hist in enumerate(histories):
+        hist = hist[-maxlen:]
+        seq_length[i] = len(hist)
+        for j, (it, ct) in enumerate(hist):
+            hist_item[i, j] = it
+            hist_cate[i, j] = ct
+
+    feature_columns = [
+        SparseFeat("user", n_users, embedding_dim=embedding_dim),
+        SparseFeat("gender", 2, embedding_dim=embedding_dim),
+        SparseFeat("item_id", n_items + 1, embedding_dim=embedding_dim),
+        SparseFeat("cate_id", n_cates + 1, embedding_dim=embedding_dim),
+        DenseFeat("pay_score", 1),
+        VarLenSparseFeat(
+            SparseFeat("hist_item_id", n_items + 1, embedding_dim=embedding_dim, embedding_name="item_id"),
+            maxlen=maxlen, length_name="seq_length"),
+        VarLenSparseFeat(
+            SparseFeat("hist_cate_id", n_cates + 1, embedding_dim=embedding_dim, embedding_name="cate_id"),
+            maxlen=maxlen, length_name="seq_length"),
+    ]
+    feature_dict = {
+        "user": np.array(users), "gender": np.array(genders),
+        "item_id": np.array(items), "cate_id": np.array(cates),
+        "pay_score": np.array(scores, dtype="float32"),
+        "hist_item_id": hist_item, "hist_cate_id": hist_cate, "seq_length": seq_length,
+    }
+    x = {k: feature_dict[k] for k in get_feature_names(feature_columns)}
+    train_x, train_y, test_x, test_y = split_dict_xy(x, np.array(ys).reshape(-1, 1), test_size, seed)
+    return SequenceData(name, feature_columns, ["item_id", "cate_id"],
+                        train_x, train_y, test_x, test_y, sess_max_count=0)
+
+
+def _to_dsin_data(samples, sess_len, sess_max_count, embedding_dim, test_size, seed, name):
+    users, genders, items, cates, scores, histories, ys, (n_users, n_items, n_cates) = samples
+    n = len(ys)
+    sess_item = [np.zeros((n, sess_len), dtype="int64") for _ in range(sess_max_count)]
+    sess_cate = [np.zeros((n, sess_len), dtype="int64") for _ in range(sess_max_count)]
+    sess_length = np.zeros((n,), dtype="int64")
+    for i, hist in enumerate(histories):
+        chunks = [hist[k:k + sess_len] for k in range(0, len(hist), sess_len)][:sess_max_count]
+        sess_length[i] = len(chunks)
+        for s, chunk in enumerate(chunks):
+            for j, (it, ct) in enumerate(chunk):
+                sess_item[s][i, j] = it
+                sess_cate[s][i, j] = ct
+
+    feature_columns = [
+        SparseFeat("user", n_users, embedding_dim=embedding_dim),
+        SparseFeat("gender", 2, embedding_dim=embedding_dim),
+        SparseFeat("item", n_items + 1, embedding_dim=embedding_dim),
+        SparseFeat("cate_id", n_cates + 1, embedding_dim=embedding_dim),
+        DenseFeat("pay_score", 1),
+    ]
+    feature_dict = {
+        "user": np.array(users), "gender": np.array(genders),
+        "item": np.array(items), "cate_id": np.array(cates),
+        "pay_score": np.array(scores, dtype="float32"),
+    }
+    for k in range(sess_max_count):
+        feature_columns += [
+            VarLenSparseFeat(
+                SparseFeat("sess_%d_item" % k, n_items + 1, embedding_dim=embedding_dim, embedding_name="item"),
+                maxlen=sess_len),
+            VarLenSparseFeat(
+                SparseFeat("sess_%d_cate_id" % k, n_cates + 1, embedding_dim=embedding_dim, embedding_name="cate_id"),
+                maxlen=sess_len),
+        ]
+        feature_dict["sess_%d_item" % k] = sess_item[k]
+        feature_dict["sess_%d_cate_id" % k] = sess_cate[k]
+
+    x = {k: feature_dict[k] for k in get_feature_names(feature_columns)}
+    x["sess_length"] = sess_length  # DSIN reads this directly (not a feature column)
+    train_x, train_y, test_x, test_y = split_dict_xy(x, np.array(ys).reshape(-1, 1), test_size, seed)
+    return SequenceData(name, feature_columns, ["item", "cate_id"],
+                        train_x, train_y, test_x, test_y, sess_max_count=sess_max_count)
+
+
+def make_sequence_datasets(source="synthetic", n_samples=2000, n_users=100, n_items=50,
+                           n_cates=8, max_hist=8, sess_max_count=3, sess_len=4,
+                           embedding_dim=8, test_size=0.2, seed=2020, data_path=None):
+    """Build both sequence views from one behavior source.
+
+    Returns ``(din_data, dsin_data)``: ``din_data`` feeds DIN/BST/DIEN,
+    ``dsin_data`` feeds DSIN.
+    """
+    if source == "movielens":
+        path = data_path or os.path.join(EXAMPLES_DIR, "movielens_sample.txt")
+        samples = _generate_movielens(path, max_hist=sess_max_count * sess_len)
+        name = "movielens_seq"
+    else:
+        samples = _generate_synthetic(n_samples, n_users, n_items, n_cates,
+                                      max_hist=sess_max_count * sess_len, seed=seed)
+        name = "synthetic_seq"
+
+    din_data = _to_din_data(samples, max_hist, embedding_dim, test_size, seed, name)
+    dsin_data = _to_dsin_data(samples, sess_len, sess_max_count, embedding_dim, test_size, seed, name)
+    return din_data, dsin_data

--- a/benchmarks/metrics.py
+++ b/benchmarks/metrics.py
@@ -1,0 +1,52 @@
+"""Evaluation metrics for the benchmark suite.
+
+Thin wrappers over scikit-learn so every track reports metrics the same way:
+binary classification -> AUC + LogLoss, regression -> MSE + RMSE.
+"""
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+from sklearn.metrics import log_loss, mean_squared_error, roc_auc_score
+
+
+def binary_metrics(y_true, y_pred):
+    """AUC and LogLoss for a single binary task.
+
+    AUC is undefined when ``y_true`` has a single class (can happen on tiny
+    test splits); we return NaN in that case instead of raising.
+    """
+    y_true = np.asarray(y_true).reshape(-1)
+    y_pred = np.asarray(y_pred).reshape(-1)
+    out = {}
+    try:
+        out["AUC"] = round(float(roc_auc_score(y_true, y_pred)), 4)
+    except ValueError:
+        out["AUC"] = float("nan")
+    # labels=[0, 1] keeps log_loss well-defined even if a split is single-class.
+    out["LogLoss"] = round(float(log_loss(y_true, y_pred, labels=[0, 1])), 4)
+    return out
+
+
+def regression_metrics(y_true, y_pred):
+    """MSE and RMSE for a single regression task."""
+    y_true = np.asarray(y_true).reshape(-1)
+    y_pred = np.asarray(y_pred).reshape(-1)
+    mse = float(mean_squared_error(y_true, y_pred))
+    return {"MSE": round(mse, 4), "RMSE": round(float(np.sqrt(mse)), 4)}
+
+
+def compute_metrics(task, y_true, y_pred):
+    """Dispatch to the right metric set for ``task`` ('binary' or 'regression')."""
+    if task == "regression":
+        return regression_metrics(y_true, y_pred)
+    return binary_metrics(y_true, y_pred)
+
+
+# Direction of the headline metric, used by the leaderboard sorter.
+HIGHER_IS_BETTER = {
+    "AUC": True,
+    "LogLoss": False,
+    "MSE": False,
+    "RMSE": False,
+    "mean_AUC": True,
+}

--- a/benchmarks/onboard/DESIGN.md
+++ b/benchmarks/onboard/DESIGN.md
@@ -1,0 +1,162 @@
+> **Status:** original design plan for the model-onboarding pipeline, kept in-repo
+> for reference across machines. For day-to-day **usage** see
+> [`benchmarks/onboard/README.md`](./README.md) and the repo-root `AGENTS.md`.
+>
+> A few details evolved during implementation:
+> - Templates are split per category: `model_single.py.tmpl`,
+>   `model_sequence.py.tmpl`, `model_multitask.py.tmpl`, `layer.py.tmpl`,
+>   `test_single.py.tmpl`, `test_sequence.py.tmpl`, `test_multitask.py.tmpl`.
+> - `discover --refresh` prints a tool-agnostic research prompt (no hard
+>   dependency on any specific agent's web-search tool).
+> - OneTrans's positional-encoding class was renamed to
+>   `SinusoidalPositionEncoding` to avoid a name collision with
+>   `deepctr.layers.sequence.PositionEncoding`; a serializable `TokenSlice`
+>   layer replaced an inline `Lambda`.
+> - `docs.py` updates README / Features / rst+toctree / History / RESULTS;
+>   `docs/source/index.rst` is left to manual edits (no stable counter anchor).
+
+---
+
+# 计划：DeepCTR 新模型自动化加入流程（model onboarding pipeline）
+
+## Context（为什么做这件事）
+
+DeepCTR 收录的模型停留在几年前，没有跟进近年（2021+）业界/学界的新 CTR 模型，影响项目的影响力与可持续发展。用户希望建立一条**自动化的新模型加入流程**，让"发现 → 实现 → 验证 → 文档"四个环节标准化、可复用，从而让项目能持续吸收新模型、保持活力。
+
+现状暴露的核心痛点（以正在手工加入的 **OneTrans** 为活证据）：手工加一个模型要改 6 个分散的集成点，极易漏接。OneTrans 当时只接了一半——
+- ✅ `deepctr/layers/onetrans.py`、`deepctr/models/sequence/onetrans.py` 已实现；
+- ✅ 已在 `deepctr/layers/__init__.py` import、`deepctr/models/sequence/__init__.py` import；
+- ❌ **未**注册到 `deepctr/layers/__init__.py` 的 `custom_objects`（导致 save/load 失败）；
+- ❌ **未**在 `deepctr/models/__init__.py` 的 import 行与 `__all__` 中导出（`from deepctr.models import OneTrans` 会失败）；
+- ❌ 无单测、无 `benchmarks/registry.py` 条目、无文档。
+
+目标产物：一个**独立 CLI 工具** `python -m benchmarks.onboard <command>`，覆盖发现/实现脚手架/benchmark 验证/文档四阶段，并用 **OneTrans + FinalMLP + MaskNet** 跑通验证。运行方式为独立 CLI，不强绑 CI。
+
+---
+
+## 总体架构
+
+新增子包 `benchmarks/onboard/`，复用现有 benchmark 基础设施（`benchmarks/registry.py`、`benchmark.py`、`common.py`、`metrics.py`）与模型基建（`deepctr/inputs.py` 的 `build_input_features`/`input_from_feature_columns`/`combined_dnn_input`/`get_linear_logit`、`deepctr/layers`、`tests/utils.py` 的 `check_model`/`get_test_data`）。
+
+```
+benchmarks/onboard/
+  __init__.py
+  __main__.py          # CLI 入口：python -m benchmarks.onboard <cmd>
+  candidates.json      # 候选模型知识库（发现阶段产物，受版本控制）
+  discover.py          # 阶段1：发现
+  scaffold.py          # 阶段2：脚手架/接线
+  verify.py            # 阶段3：benchmark 验证（正确性+效果）
+  docs.py              # 阶段4：文档自动更新
+  audit.py             # 横切：集成完整性校验（抓 OneTrans 式半接线）
+  templates/           # 模型/单测/layer 代码模板（按 category 拆分）
+```
+
+CLI 子命令：`discover` / `scaffold` / `verify` / `docs` / `audit` / `onboard`（串联）。
+
+---
+
+## 阶段 1 — 发现（`discover.py`）
+
+**产物**：`benchmarks/onboard/candidates.json`，每条候选含固定 schema：
+`name, paper_title, year, venue, category(single|sequence|multitask), one_liner, ref_impl_url, paper_metric(如 {dataset:"Criteo", AUC:0.8xx}), difficulty, status(candidate|implemented|skipped)`。
+
+**实现**：
+- `discover --refresh`：打印工具无关的研究提示，让执行 agent 用自身联网检索能力扫 arXiv、paperswithcode CTR 榜、近年 KDD/RecSys/CIKM/SIGIR/WWW、FuxiCTR/BARS 等基准库，抽取候选并按"与 DeepCTR feature-column 接口契合度 + 引用度 + 是否已收录"排序，合并进 `candidates.json`（去重、保留 `status`）。
+- `discover --list`：离线列出/筛选候选，标出未实现项。
+
+> 说明：模型选型本质需要人/LLM 判断，CLI 负责把"检索 → 结构化 → 排序 → 标记状态"自动化，并产出可评审的候选表。
+
+---
+
+## 阶段 2 — 实现脚手架与接线（`scaffold.py`）
+
+消灭 6 点手工 checklist。`scaffold <name> --category single|sequence|multitask [--with-layer] [--wire-only]`：
+
+1. 从 `templates/` 生成：
+   - `deepctr/models/<name>.py`（或 `sequence/`、`multitask/` 子目录），遵循工厂函数范式：`build_input_features → input_from_feature_columns → combined_dnn_input → [模型核心 # TODO] → DNN → Dense(1) → PredictionLayer → Model`（参考 `deepctr/models/wdl.py`）。核心交互层留明确 `# TODO` 占位，由人/LLM 补全数学。
+   - 需自定义层时 `deepctr/layers/<name>.py`（`--with-layer`）。
+   - `tests/models/<Name>_test.py`，用 `get_test_data` + `check_model`（照搬 `tests/models/DeepFM_test.py` 范式）。
+2. **自动接线全部注册点**（锚点安全插入，幂等）：
+   - `deepctr/models/__init__.py`：import 行 + `__all__`；
+   - 子包 `deepctr/models/{sequence,multitask}/__init__.py`：import；
+   - `deepctr/layers/__init__.py`：layer import + **`custom_objects` 字典**（OneTrans 漏的就是这一项）；
+   - `benchmarks/registry.py`：对应 `SINGLE_TASK_MODELS` / `MULTITASK_MODELS` / `SEQUENCE_MODELS` 加 builder（sequence 自动生成 `_build_<name>` 处理 head/embedding 约束）。
+- `--wire-only`：模型已存在（如 OneTrans）时只补接线 + 生成缺失的单测/registry 条目，不重生成模型主体。
+
+---
+
+## 阶段 3 — benchmark 验证（`verify.py`）
+
+`verify <name>` 产出"正确性 + 效果"双结论与报告（`benchmarks/onboard/reports/<name>.md`）。
+
+- **正确性**：跑 `pytest tests/models/<Name>_test.py`（编译/训练 1 epoch/save-load 往返——直接验证 `custom_objects` 是否齐全）；并对该模型跑 `audit`。
+- **效果**：复用 `benchmarks.benchmark.run_single/run_multitask/run_sequence`，跑 `<新模型 + 同 track 基线（single=DeepFM / sequence=DIN / multitask=SharedBottom）>`，比较 AUC；若候选含 `paper_metric` 则与论文报告值对标，给出 verdict。
+- 强制 `CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1`。
+
+---
+
+## 横切 — 集成完整性校验（`audit.py`）
+
+`audit [--name X]`：自动发现 `deepctr.models` 下所有模型符号，逐项断言全接线，输出差距表：
+可 `from deepctr.models import X` ✓ / 在 `__all__` ✓ / 自定义层在 `custom_objects` ✓ / 有 `tests/models/X_test.py` ✓ / 有 `benchmarks/registry.py` builder ✓。
+这能立刻把 OneTrans 当时的半接线状态报出来。
+
+---
+
+## 阶段 4 — 文档自动更新（`docs.py`）
+
+`docs <name>` 用锚点插入，幂等更新：
+- `README.md` 模型表追加一行（名称 + 论文链接）；
+- `docs/source/Features.md` 追加 `### <Name>` 小节；
+- 新建 `docs/source/deepctr.models[.sequence|.multitask].<name>.rst` autodoc stub，并加入 `docs/source/deepctr.models.rst` 的 toctree；
+- `docs/source/History.md` 追加变更行；
+- `benchmarks/RESULTS.md` 记录该模型最近一次 `verify` 结果。
+
+---
+
+## 已落地的模型
+
+1. **OneTrans**（序列）— 走 `scaffold --wire-only` 补全接线，`verify` 阶段抓出并修复 4 个真实 bug（positional `add_weight`、`tensorflow.python.keras` import、`Lambda` 序列化 → `TokenSlice`、`PositionEncoding` 类名冲突 → `SinusoidalPositionEncoding`）。
+2. **FinalMLP**（AAAI 2023）、**MaskNet**（DLP-KDD 2021）（单任务）— 走完整 `discover → scaffold → 补核心数学 → verify → docs`，证明全链路可复用。
+
+---
+
+## 关键复用点（不要重造）
+
+- 模型骨架：`deepctr/inputs.py`、`deepctr/layers`（`DNN`/`PredictionLayer`/`FM`/`InteractingLayer` 等）。
+- 范式样例：`deepctr/models/wdl.py`（单任务）、`deepctr/models/sequence/din.py`/`bst.py`（序列）、`deepctr/models/multitask/mmoe.py`（多任务）。
+- 测试：`tests/utils.py::check_model`/`get_test_data`、`tests/utils_mtl.py::check_mtl_model`/`get_mtl_test_data`。
+- benchmark：`benchmarks/registry.py`、`benchmarks/benchmark.py::run_single/run_multitask/run_sequence`、`benchmarks/common.py`、`benchmarks/metrics.py`。
+- feature 定义：`deepctr/feature_column.py`。
+
+---
+
+## 验证（端到端如何测）
+
+```bash
+export CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1
+
+# 接线完整性
+python -m benchmarks.onboard audit
+
+# 新模型全链路（以 FinalMLP 为例）
+python -m benchmarks.onboard discover --list
+python -m benchmarks.onboard scaffold FinalMLP --category single
+#   ↳ 人/LLM 补全 deepctr/models/finalmlp.py 的核心交互
+python -m benchmarks.onboard verify FinalMLP
+python -m benchmarks.onboard docs FinalMLP
+
+# 回归
+python -m pytest tests/benchmark_test.py -q
+python -m benchmarks.benchmark --track all --quick
+```
+
+通过标准：`audit` 全绿；新模型可 `from deepctr.models import X`、单测 save-load 往返通过、benchmark 跑出 AUC、文档各处出现新模型条目；既有测试不回归。
+
+---
+
+## 不在本次范围
+
+- 不接 CI 闸门（独立 CLI 取向）。
+- `discover` 的全自动联网研究依赖外部检索，首批候选以人工/研究填充为准。
+- 不改 `deepctr/estimator/` 旧 Estimator 路径。

--- a/benchmarks/onboard/README.md
+++ b/benchmarks/onboard/README.md
@@ -19,7 +19,7 @@ export TF_USE_LEGACY_KERAS=1        # requires `pip install tf-keras==<your TF x
 | Command | What it does |
 | --- | --- |
 | `discover --list` | List/rank candidate models from `candidates.json`; marks which are already implemented. |
-| `discover --refresh` | Print a research prompt to refresh the candidate KB via web search / the deep-research skill. |
+| `discover --refresh` | Print a research prompt to refresh the candidate KB using your own web-search capability. |
 | `scaffold <Name> --category single\|sequence\|multitask` | Generate model + test skeletons and **auto-wire all 6 registration points** (`deepctr/models/__init__.py` import + `__all__`, sub-package `__init__`, `deepctr/layers/__init__.py` `custom_objects`, `benchmarks/registry.py`). Use `--with-layer` to also create a custom layer, `--wire-only` for an already-written model. |
 | `audit [--name X ...]` | Check every discovered model is fully wired (importable, in `__all__`, custom layers registered, has a test, has a registry builder). Catches half-integrated models. |
 | `verify <Name>` | Correctness (unit test + audit) **and** effectiveness (benchmark AUC vs an in-track baseline, compared to the paper number). Writes `reports/<Name>.md`. |

--- a/benchmarks/onboard/README.md
+++ b/benchmarks/onboard/README.md
@@ -1,0 +1,46 @@
+# Model onboarding pipeline (`benchmarks.onboard`)
+
+A standalone CLI that standardizes adding a new CTR model to DeepCTR across four
+stages, so the project can keep absorbing recent industry/academic models:
+
+```
+discover  ->  scaffold  ->  (implement core)  ->  verify  ->  docs
+```
+
+Run everything CPU-only with legacy Keras (DeepCTR targets the Keras 2 API):
+
+```bash
+export CUDA_VISIBLE_DEVICES=""
+export TF_USE_LEGACY_KERAS=1        # requires `pip install tf-keras==<your TF x.y>` on TF>=2.16
+```
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `discover --list` | List/rank candidate models from `candidates.json`; marks which are already implemented. |
+| `discover --refresh` | Print a research prompt to refresh the candidate KB via web search / the deep-research skill. |
+| `scaffold <Name> --category single\|sequence\|multitask` | Generate model + test skeletons and **auto-wire all 6 registration points** (`deepctr/models/__init__.py` import + `__all__`, sub-package `__init__`, `deepctr/layers/__init__.py` `custom_objects`, `benchmarks/registry.py`). Use `--with-layer` to also create a custom layer, `--wire-only` for an already-written model. |
+| `audit [--name X ...]` | Check every discovered model is fully wired (importable, in `__all__`, custom layers registered, has a test, has a registry builder). Catches half-integrated models. |
+| `verify <Name>` | Correctness (unit test + audit) **and** effectiveness (benchmark AUC vs an in-track baseline, compared to the paper number). Writes `reports/<Name>.md`. |
+| `docs <Name>` | Idempotently update `README.md`, `docs/source/Features.md`, the autodoc `.rst` + toctree, `History.md`, and `RESULTS.md`. |
+| `onboard <Name> --category ...` | `scaffold` → (pause to implement the core) → `verify` → `docs`. |
+
+## Typical flow for a new model
+
+```bash
+python -m benchmarks.onboard discover --list
+python -m benchmarks.onboard scaffold FinalMLP --category single   # generates + wires
+#   implement the model core in deepctr/models/finalmlp.py (replace the TODO block)
+python -m benchmarks.onboard verify FinalMLP                        # correctness + effectiveness
+python -m benchmarks.onboard docs   FinalMLP                        # update all docs
+python -m benchmarks.onboard audit                                  # confirm 100% wired
+```
+
+## Notes
+
+- `candidates.json` is the version-controlled knowledge base of candidate models.
+- `reports/<Name>.md` are kept as artifacts; transient benchmark leaderboards go
+  to the gitignored `benchmarks/results/`.
+- Scaffolded test files use a generic signature; adjust the generated
+  `tests/models/<Name>_test.py` if your model's constructor differs (e.g. FinalMLP).

--- a/benchmarks/onboard/README.md
+++ b/benchmarks/onboard/README.md
@@ -20,9 +20,9 @@ export TF_USE_LEGACY_KERAS=1        # requires `pip install tf-keras==<your TF x
 | --- | --- |
 | `discover --list` | List/rank candidate models from `candidates.json`; marks which are already implemented. |
 | `discover --refresh` | Print a research prompt to refresh the candidate KB using your own web-search capability. |
-| `scaffold <Name> --category single\|sequence\|multitask` | Generate model + test skeletons and **auto-wire all 6 registration points** (`deepctr/models/__init__.py` import + `__all__`, sub-package `__init__`, `deepctr/layers/__init__.py` `custom_objects`, `benchmarks/registry.py`). Use `--with-layer` to also create a custom layer, `--wire-only` for an already-written model. |
+| `scaffold <Name> --category single\|sequence\|multitask` | Generate model + test skeletons and **auto-wire all 6 registration points** (`deepctr/models/__init__.py` import + `__all__`, sub-package `__init__`, `deepctr/layers/__init__.py` `custom_objects`, `benchmarks/registry.py`). Use `--with-layer` to also create a custom layer plus an independent reference/gradient correctness-test skeleton; use `--wire-only` for an already-written model. |
 | `audit [--name X ...]` | Check every discovered model is fully wired (importable, in `__all__`, custom layers registered, has a test, has a registry builder). Catches half-integrated models. |
-| `verify <Name>` | Correctness (unit test + audit) **and** effectiveness (benchmark AUC vs an in-track baseline, compared to the paper number). Writes `reports/<Name>.md`. |
+| `verify <Name>` | Correctness (model test, matching layer correctness contract when present, and audit) **and** effectiveness (benchmark AUC vs an in-track baseline, compared to the paper number). Writes `reports/<Name>.md`. |
 | `docs <Name>` | Idempotently update `README.md`, `docs/source/Features.md`, the autodoc `.rst` + toctree, `History.md`, and `RESULTS.md`. |
 | `onboard <Name> --category ...` | `scaffold` → (pause to implement the core) → `verify` → `docs`. |
 
@@ -32,6 +32,8 @@ export TF_USE_LEGACY_KERAS=1        # requires `pip install tf-keras==<your TF x
 python -m benchmarks.onboard discover --list
 python -m benchmarks.onboard scaffold FinalMLP --category single   # generates + wires
 #   implement the model core in deepctr/models/finalmlp.py (replace the TODO block)
+#   if a custom layer was generated, replace the identity NumPy reference in
+#   tests/layers/FinalMLP_correctness_test.py with the paper equation
 python -m benchmarks.onboard verify FinalMLP                        # correctness + effectiveness
 python -m benchmarks.onboard docs   FinalMLP                        # update all docs
 python -m benchmarks.onboard audit                                  # confirm 100% wired
@@ -46,3 +48,7 @@ For the design rationale and why each stage exists, see [`DESIGN.md`](./DESIGN.m
   to the gitignored `benchmarks/results/`.
 - Scaffolded test files use a generic signature; adjust the generated
   `tests/models/<Name>_test.py` if your model's constructor differs (e.g. FinalMLP).
+- `check_model` supplies the generic build/train/serialization contract. It
+  cannot prove a paper equation. Custom mathematical layers must additionally
+  use the C3-C5 helpers in `tests/correctness.py`; see `tests/README.md` for the
+  correctness ladder and concrete examples.

--- a/benchmarks/onboard/README.md
+++ b/benchmarks/onboard/README.md
@@ -37,6 +37,8 @@ python -m benchmarks.onboard docs   FinalMLP                        # update all
 python -m benchmarks.onboard audit                                  # confirm 100% wired
 ```
 
+For the design rationale and why each stage exists, see [`DESIGN.md`](./DESIGN.md).
+
 ## Notes
 
 - `candidates.json` is the version-controlled knowledge base of candidate models.

--- a/benchmarks/onboard/__init__.py
+++ b/benchmarks/onboard/__init__.py
@@ -1,0 +1,24 @@
+"""DeepCTR model-onboarding pipeline.
+
+A standalone CLI that standardizes the four stages of adding a new CTR model to
+DeepCTR so the project can keep absorbing recent industry/academic models:
+
+    discover  -> find & rank candidate models (knowledge base + optional web sweep)
+    scaffold  -> generate model/test skeletons AND auto-wire every registration point
+    audit     -> verify a model is fully wired (catches OneTrans-style half-integration)
+    verify    -> prove correctness (unit test + audit) and effectiveness (benchmark AUC)
+    docs      -> update README / Features / rst / History / RESULTS
+
+Run with:  python -m benchmarks.onboard <command> [options]
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+
+# DeepCTR targets the Keras 2 API; force legacy Keras on TF>=2.16 before any TF import.
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
+
+# Repository root (…/DeepCTR), derived from this file's location.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+__all__ = ["REPO_ROOT"]

--- a/benchmarks/onboard/__main__.py
+++ b/benchmarks/onboard/__main__.py
@@ -1,0 +1,118 @@
+"""CLI entry point: ``python -m benchmarks.onboard <command> [options]``.
+
+Commands
+--------
+  discover   list / refresh the candidate-model knowledge base
+  scaffold   generate model+test skeletons and auto-wire all registration points
+  audit      check that discovered models are fully wired
+  verify     prove correctness (unit test + audit) and effectiveness (benchmark)
+  docs       update README / Features / rst / History / RESULTS for a model
+  onboard    run scaffold -> verify -> docs end to end
+"""
+from __future__ import absolute_import, division, print_function
+
+import argparse
+import sys
+
+
+def build_parser():
+    p = argparse.ArgumentParser(prog="python -m benchmarks.onboard",
+                                description="DeepCTR model-onboarding pipeline.")
+    sub = p.add_subparsers(dest="command")
+
+    # -- discover --
+    d = sub.add_parser("discover", help="list/refresh candidate models")
+    d.add_argument("--list", action="store_true", help="list candidates (default)")
+    d.add_argument("--refresh", action="store_true",
+                   help="print a research prompt to refresh candidates.json via web search")
+    d.add_argument("--category", choices=["single", "sequence", "multitask"], default=None)
+    d.add_argument("--status", default=None, help="filter by status (candidate/implemented/skipped)")
+
+    # -- scaffold --
+    s = sub.add_parser("scaffold", help="generate + wire a new model")
+    s.add_argument("name")
+    s.add_argument("--category", choices=["single", "sequence", "multitask"], required=True)
+    s.add_argument("--with-layer", action="store_true", help="also create a custom layer file")
+    s.add_argument("--wire-only", action="store_true",
+                   help="model already exists; only add registration + test + registry")
+    s.add_argument("--paper-title", default="")
+    s.add_argument("--paper-url", default="")
+
+    # -- audit --
+    a = sub.add_parser("audit", help="check model wiring completeness")
+    a.add_argument("--name", nargs="*", help="restrict to these model names")
+
+    # -- verify --
+    v = sub.add_parser("verify", help="correctness + effectiveness validation")
+    v.add_argument("name")
+    v.add_argument("--category", choices=["single", "sequence", "multitask"], default=None)
+    v.add_argument("--data-path", default=None, help="real dataset path for the benchmark")
+    v.add_argument("--epochs", type=int, default=1)
+    v.add_argument("--batch-size", type=int, default=1024)
+    v.add_argument("--baseline", default=None,
+                   help="comparison model (default: in-track baseline — "
+                        "DeepFM/DIN/SharedBottom)")
+    v.add_argument("--quick", action="store_true", help="bundled tiny data, smoke only")
+    v.add_argument("--skip-benchmark", action="store_true", help="run correctness checks only")
+
+    # -- docs --
+    dc = sub.add_parser("docs", help="update documentation for a model")
+    dc.add_argument("name")
+    dc.add_argument("--category", choices=["single", "sequence", "multitask"], default=None)
+    dc.add_argument("--paper-title", default="")
+    dc.add_argument("--paper-url", default="")
+    dc.add_argument("--one-liner", default="")
+
+    # -- onboard --
+    o = sub.add_parser("onboard", help="scaffold -> verify -> docs")
+    o.add_argument("name")
+    o.add_argument("--category", choices=["single", "sequence", "multitask"], required=True)
+    o.add_argument("--with-layer", action="store_true")
+    o.add_argument("--wire-only", action="store_true")
+    o.add_argument("--quick", action="store_true")
+    o.add_argument("--paper-title", default="")
+    o.add_argument("--paper-url", default="")
+    o.add_argument("--one-liner", default="")
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if not args.command:
+        build_parser().print_help()
+        return 0
+
+    if args.command == "audit":
+        from . import audit
+        return audit.run(args)
+    if args.command == "discover":
+        from . import discover
+        return discover.run(args)
+    if args.command == "scaffold":
+        from . import scaffold
+        return scaffold.run(args)
+    if args.command == "verify":
+        from . import verify
+        return verify.run(args)
+    if args.command == "docs":
+        from . import docs
+        return docs.run(args)
+    if args.command == "onboard":
+        from . import scaffold, verify, docs
+        rc = scaffold.run(args)
+        if rc:
+            return rc
+        if not args.wire_only:
+            print("\n>>> Implement the model core (marked with TODO), then re-run "
+                  "verify/docs. Pausing onboard before verification.")
+            return 0
+        rc = verify.run(args)
+        if rc:
+            print("\nverify failed; fix issues before updating docs.")
+            return rc
+        return docs.run(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/onboard/_util.py
+++ b/benchmarks/onboard/_util.py
@@ -1,0 +1,265 @@
+"""Shared helpers for the onboarding CLI: repo paths, model-source discovery,
+and idempotent anchor-based file editing used by scaffold/docs.
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import re
+
+from . import REPO_ROOT
+
+# --------------------------------------------------------------------------- #
+# Paths
+# --------------------------------------------------------------------------- #
+MODELS_INIT = os.path.join(REPO_ROOT, "deepctr", "models", "__init__.py")
+SEQUENCE_INIT = os.path.join(REPO_ROOT, "deepctr", "models", "sequence", "__init__.py")
+MULTITASK_INIT = os.path.join(REPO_ROOT, "deepctr", "models", "multitask", "__init__.py")
+LAYERS_INIT = os.path.join(REPO_ROOT, "deepctr", "layers", "__init__.py")
+REGISTRY_PY = os.path.join(REPO_ROOT, "benchmarks", "registry.py")
+TESTS_MODELS_DIR = os.path.join(REPO_ROOT, "tests", "models")
+
+CATEGORY_INIT = {
+    "single": MODELS_INIT,
+    "sequence": SEQUENCE_INIT,
+    "multitask": MULTITASK_INIT,
+}
+CATEGORY_PKG_DIR = {
+    "single": os.path.join(REPO_ROOT, "deepctr", "models"),
+    "sequence": os.path.join(REPO_ROOT, "deepctr", "models", "sequence"),
+    "multitask": os.path.join(REPO_ROOT, "deepctr", "models", "multitask"),
+}
+CATEGORY_REGISTRY = {
+    "single": "SINGLE_TASK_MODELS",
+    "sequence": "SEQUENCE_MODELS",
+    "multitask": "MULTITASK_MODELS",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Plain file IO
+# --------------------------------------------------------------------------- #
+def read_text(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def write_text(path, text):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+# --------------------------------------------------------------------------- #
+# Model-source discovery
+# --------------------------------------------------------------------------- #
+_IMPORT_RE = re.compile(r"^from\s+\.(\S+)\s+import\s+(.+)$", re.MULTILINE)
+
+
+def _parse_imports(init_path):
+    """Return list of (module, [names]) from ``from .module import a, b`` lines."""
+    out = []
+    if not os.path.exists(init_path):
+        return out
+    for mod, names in _IMPORT_RE.findall(read_text(init_path)):
+        clean = []
+        for tok in names.split(","):
+            tok = tok.strip()
+            if " as " in tok:
+                tok = tok.split(" as ")[-1].strip()
+            if tok:
+                clean.append(tok)
+        out.append((mod, clean))
+    return out
+
+
+def discover_models():
+    """Discover every model symbol across the three model __init__ files.
+
+    Returns a dict: name -> {"category", "module", "init"}.  ``module`` is the
+    dotted submodule the model is defined in (e.g. ``sequence.onetrans``).
+    Captures models that exist in a sub-package even if they are NOT yet
+    re-exported from the top-level ``deepctr.models`` namespace (e.g. OneTrans).
+    """
+    models = {}
+
+    for mod, names in _parse_imports(SEQUENCE_INIT):
+        for n in names:
+            models[n] = {"category": "sequence", "module": "sequence." + mod, "init": SEQUENCE_INIT}
+    for mod, names in _parse_imports(MULTITASK_INIT):
+        for n in names:
+            models[n] = {"category": "multitask", "module": "multitask." + mod, "init": MULTITASK_INIT}
+
+    # Top-level: direct `from .mod import Name` are single-task; the aggregate
+    # `from .multitask/.sequence import ...` lines are skipped (already covered).
+    for mod, names in _parse_imports(MODELS_INIT):
+        if mod in ("multitask", "sequence"):
+            continue
+        for n in names:
+            models.setdefault(n, {"category": "single", "module": mod, "init": MODELS_INIT})
+
+    return models
+
+
+def models_all_list():
+    """Return the names currently in ``deepctr.models.__all__`` (textually)."""
+    text = read_text(MODELS_INIT)
+    m = re.search(r"__all__\s*=\s*\[(.*?)\]", text, re.DOTALL)
+    if not m:
+        return []
+    return re.findall(r"""['"]([A-Za-z_][\w]*)['"]""", m.group(1))
+
+
+def layers_custom_objects():
+    """Return (imported_layer_names, registered_keys) from deepctr/layers/__init__.py.
+
+    ``imported_layer_names`` are CapWords symbols imported into the layers package;
+    ``registered_keys`` are the string keys present in the ``custom_objects`` dict.
+    """
+    text = read_text(LAYERS_INIT)
+    imported = set()
+    for _mod, names in _parse_imports(LAYERS_INIT):
+        for n in names:
+            if n[:1].isupper():  # layer classes are CapWords
+                imported.add(n)
+    co = re.search(r"custom_objects\s*=\s*\{(.*?)\n\s*\}", text, re.DOTALL)
+    registered = set(re.findall(r"""['"]([\w]+)['"]\s*:""", co.group(1))) if co else set()
+    return imported, registered
+
+
+def registry_entries(category):
+    """Return the set of model names registered in the given registry dict."""
+    text = read_text(REGISTRY_PY)
+    dict_name = CATEGORY_REGISTRY[category]
+    m = re.search(dict_name + r"\s*=\s*\{(.*?)\n\}", text, re.DOTALL)
+    if not m:
+        return set()
+    return set(re.findall(r"""['"]([\w]+)['"]\s*:""", m.group(1)))
+
+
+def all_registry_entries():
+    out = {}
+    for cat in CATEGORY_REGISTRY:
+        for name in registry_entries(cat):
+            out[name] = cat
+    return out
+
+
+def test_file_for(name):
+    """Path to the per-model test file if it exists, else None.
+
+    Also treats the shared multitask test (MTL_test.py) as covering a model when
+    the model name appears inside it.
+    """
+    direct = os.path.join(TESTS_MODELS_DIR, name + "_test.py")
+    if os.path.exists(direct):
+        return direct
+    # fall back: any test file that references the model symbol
+    if os.path.isdir(TESTS_MODELS_DIR):
+        for fn in os.listdir(TESTS_MODELS_DIR):
+            if fn.endswith("_test.py"):
+                p = os.path.join(TESTS_MODELS_DIR, fn)
+                if re.search(r"\b" + re.escape(name) + r"\b", read_text(p)):
+                    return p
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Idempotent anchor-based editing
+# --------------------------------------------------------------------------- #
+def ensure_line(path, line, anchor=None, after=True):
+    """Insert ``line`` into ``path`` if not already present (idempotent).
+
+    If ``anchor`` (a substring) is given, insert immediately after (or before)
+    the line containing it; otherwise append to end of file. Returns True if the
+    file was modified.
+    """
+    text = read_text(path)
+    if line in text:
+        return False
+    lines = text.splitlines(keepends=True)
+    if anchor is None:
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.append(line + "\n")
+    else:
+        idx = next((i for i, l in enumerate(lines) if anchor in l), None)
+        if idx is None:
+            raise ValueError("anchor %r not found in %s" % (anchor, path))
+        insert_at = idx + 1 if after else idx
+        lines.insert(insert_at, line + "\n")
+    write_text(path, "".join(lines))
+    return True
+
+
+def add_to_import_line(path, module, name):
+    """Append ``name`` to an existing ``from .<module> import a, b`` line. Idempotent."""
+    text = read_text(path)
+    pat = re.compile(r"^(from\s+\.%s\s+import\s+)(.+)$" % re.escape(module), re.MULTILINE)
+    m = pat.search(text)
+    if not m:
+        raise ValueError("import line for module %r not found in %s" % (module, path))
+    names = m.group(2)
+    if re.search(r"\b%s\b" % re.escape(name), names):
+        return False
+    new = m.group(1) + names.rstrip() + ", " + name
+    write_text(path, text[:m.start()] + new + text[m.end():])
+    return True
+
+
+def add_to_paren_import(path, name, module="deepctr.models"):
+    """Add ``name`` into a parenthesized ``from <module> import (a, b, ...)`` block. Idempotent."""
+    text = read_text(path)
+    pat = re.compile(r"(from\s+%s\s+import\s+\()(.*?)(\))" % re.escape(module), re.DOTALL)
+    m = pat.search(text)
+    if not m:
+        raise ValueError("parenthesized import from %r not found in %s" % (module, path))
+    body = m.group(2)
+    if re.search(r"\b%s\b" % re.escape(name), body):
+        return False
+    new_body = body.rstrip()
+    if not new_body.endswith(","):
+        new_body += ","
+    new_body += " " + name
+    write_text(path, text[:m.start(2)] + new_body + text[m.end(2):])
+    return True
+
+
+def add_to_all(path, name):
+    """Add ``name`` to the module's ``__all__`` list if missing. Idempotent."""
+    text = read_text(path)
+    m = re.search(r"(__all__\s*=\s*\[)(.*?)(\])", text, re.DOTALL)
+    if not m:
+        raise ValueError("no __all__ found in %s" % path)
+    body = m.group(2)
+    if re.search(r"""['"]%s['"]""" % re.escape(name), body):
+        return False
+    new_body = body.rstrip()
+    if not new_body.endswith(","):
+        new_body += ","
+    new_body += ' "%s"' % name
+    write_text(path, text[:m.start(2)] + new_body + text[m.end(2):])
+    return True
+
+
+def add_dict_entry(path, dict_name, key, value_expr, dict_close=r"\n\s*\}"):
+    """Add ``'key': value_expr`` before the closing brace of ``dict_name``.
+
+    Idempotent on the key. Returns True if modified.
+    """
+    text = read_text(path)
+    pat = re.compile(dict_name + r"\s*=\s*\{(.*?)(\n[ \t]*\})", re.DOTALL)
+    m = pat.search(text)
+    if not m:
+        raise ValueError("dict %s not found in %s" % (dict_name, path))
+    body = m.group(1)
+    if re.search(r"""['"]%s['"]\s*:""" % re.escape(key), body):
+        return False
+    indent = "                  "  # match deepctr/layers custom_objects indent
+    inner_indent = re.match(r"\n([ \t]*)", body)
+    if inner_indent:
+        indent = inner_indent.group(1)
+    new_body = body.rstrip()
+    if not new_body.endswith(",") and new_body.strip():
+        new_body += ","
+    new_body += "\n%s'%s': %s," % (indent, key, value_expr)
+    write_text(path, text[:m.start(1)] + new_body + text[m.end(1):])
+    return True

--- a/benchmarks/onboard/audit.py
+++ b/benchmarks/onboard/audit.py
@@ -1,0 +1,113 @@
+"""Integration completeness validator.
+
+Auto-discovers every model symbol across the deepctr.models packages and checks
+that each one is fully wired:
+
+  * importable as ``from deepctr.models import X``
+  * listed in ``deepctr.models.__all__``
+  * any custom layers it uses are registered in ``deepctr.layers.custom_objects``
+    (a missing entry silently breaks ``save_model``/``load_model``)
+  * has a unit test under ``tests/models/``
+  * has a builder in the matching ``benchmarks/registry.py`` dict
+
+Static checks only (no training) so it is fast and import-light. The deeper
+save/load round-trip is exercised by ``verify``.
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+
+from . import REPO_ROOT
+from ._util import (
+    CATEGORY_PKG_DIR, all_registry_entries, discover_models, layers_custom_objects,
+    models_all_list, read_text, test_file_for,
+)
+
+OK, FAIL, NA = "ok", "MISSING", "-"
+
+
+def _model_module_path(info):
+    """Filesystem path of the .py module a model is defined in."""
+    module = info["module"]  # e.g. "sequence.onetrans" or "deepfm"
+    parts = module.split(".")
+    return os.path.join(REPO_ROOT, "deepctr", "models", *parts) + ".py"
+
+
+def audit_models(only=None):
+    """Return (rows, summary). Each row is a dict of per-model check results."""
+    models = discover_models()
+    in_all = set(models_all_list())
+    imported_layers, registered_keys = layers_custom_objects()
+    unregistered_layers = {l for l in imported_layers if l not in registered_keys}
+    registry = all_registry_entries()
+
+    # Confirm importability through the real package (catches broken __init__).
+    importable = set()
+    try:
+        import deepctr.models as dm
+        for name in models:
+            if hasattr(dm, name):
+                importable.add(name)
+    except Exception as e:  # pragma: no cover - environment dependent
+        print("warning: could not import deepctr.models (%s); "
+              "falling back to static checks only" % e)
+        importable = set(in_all)
+
+    rows = []
+    for name in sorted(models):
+        if only and name not in only:
+            continue
+        info = models[name]
+        # Which (if any) unregistered custom layers does this model import?
+        missing_layers = []
+        mod_path = _model_module_path(info)
+        if unregistered_layers and os.path.exists(mod_path):
+            src = read_text(mod_path)
+            missing_layers = sorted(l for l in unregistered_layers if l in src)
+        rows.append({
+            "name": name,
+            "category": info["category"],
+            "import": OK if name in importable else FAIL,
+            "in_all": OK if name in in_all else FAIL,
+            "custom_objects": OK if not missing_layers else ",".join(missing_layers),
+            "test": OK if test_file_for(name) else FAIL,
+            "registry": OK if name in registry else FAIL,
+        })
+
+    summary = {
+        "total": len(rows),
+        "fully_wired": sum(1 for r in rows if _row_ok(r)),
+        "unregistered_layers": sorted(unregistered_layers),
+    }
+    return rows, summary
+
+
+def _row_ok(row):
+    return all(row[k] == OK for k in ("import", "in_all", "custom_objects", "test", "registry"))
+
+
+def _fmt_table(rows):
+    cols = [("name", 14), ("category", 10), ("import", 8), ("in_all", 8),
+            ("custom_objects", 22), ("test", 8), ("registry", 8)]
+    head = "  ".join(h.ljust(w) for h, w in cols)
+    lines = [head, "  ".join("-" * w for _h, w in cols)]
+    for r in rows:
+        lines.append("  ".join(str(r[h]).ljust(w) for h, w in cols))
+    return "\n".join(lines)
+
+
+def run(args):
+    only = set(args.name) if getattr(args, "name", None) else None
+    rows, summary = audit_models(only=only)
+    print(_fmt_table(rows))
+    print()
+    print("Fully wired: %d/%d models" % (summary["fully_wired"], summary["total"]))
+    if summary["unregistered_layers"]:
+        print("Layers imported but NOT in custom_objects (save/load will fail): %s"
+              % ", ".join(summary["unregistered_layers"]))
+    incomplete = [r["name"] for r in rows if not _row_ok(r)]
+    if incomplete:
+        print("Incomplete: %s" % ", ".join(incomplete))
+        return 1
+    print("All discovered models are fully wired.")
+    return 0

--- a/benchmarks/onboard/candidates.json
+++ b/benchmarks/onboard/candidates.json
@@ -77,6 +77,97 @@
       "paper_metric": {"dataset": "Criteo_x1", "AUC": 0.8137},
       "difficulty": "hard",
       "status": "candidate"
+    },
+    {
+      "name": "FinalNet",
+      "paper_title": "FINAL: Factorized Interaction Layer for CTR Prediction",
+      "paper_url": "https://dl.acm.org/doi/10.1145/3539618.3591988",
+      "year": 2023,
+      "venue": "SIGIR",
+      "category": "single",
+      "one_liner": "Two-stream model built on a Factorized Interaction Layer (FINAL block) that generalizes linear + quadratic feature interactions; a strong MLP-style backbone.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": {"dataset": "Criteo_x1", "AUC": 0.8137},
+      "difficulty": "medium",
+      "status": "candidate"
+    },
+    {
+      "name": "WuKong",
+      "paper_title": "Wukong: Towards a Scaling Law for Large-Scale Recommendation",
+      "paper_url": "https://arxiv.org/abs/2403.02545",
+      "year": 2024,
+      "venue": "ICML",
+      "category": "single",
+      "one_liner": "Stacks factorization-machine blocks (LCB/FMB) with MLPs into a dense architecture whose quality scales predictably with model size (a recommendation scaling law).",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": null,
+      "difficulty": "medium",
+      "status": "candidate"
+    },
+    {
+      "name": "FCN",
+      "paper_title": "FCN: Fusing Exponential and Linear Cross Network for CTR Prediction",
+      "paper_url": "https://arxiv.org/abs/2407.13349",
+      "year": 2024,
+      "venue": "arXiv",
+      "category": "single",
+      "one_liner": "Combines a Linear Cross Network with an Exponential Cross Network so the model captures both bounded- and unbounded-order feature interactions (successor to GDCN).",
+      "ref_impl_url": "",
+      "paper_metric": null,
+      "difficulty": "medium",
+      "status": "candidate"
+    },
+    {
+      "name": "QNN",
+      "paper_title": "Revisiting Feature Interactions from the Perspective of Quadratic Neural Networks for CTR Prediction",
+      "paper_url": "https://arxiv.org/abs/2505.17999",
+      "year": 2025,
+      "venue": "KDD",
+      "category": "single",
+      "one_liner": "Uses quadratic neurons (Hadamard-product interactions) as the core building block to model explicit second-order feature interactions efficiently.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": null,
+      "difficulty": "hard",
+      "status": "candidate"
+    },
+    {
+      "name": "APG",
+      "paper_title": "APG: Adaptive Parameter Generation Network for Click-Through Rate Prediction",
+      "paper_url": "https://arxiv.org/abs/2203.16218",
+      "year": 2022,
+      "venue": "NeurIPS",
+      "category": "single",
+      "one_liner": "Generates DNN weights on the fly from instance-specific conditions (adaptive/dynamic weights) instead of using a single shared MLP; a wrapper applicable to many backbones.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": null,
+      "difficulty": "hard",
+      "status": "candidate"
+    },
+    {
+      "name": "TransAct",
+      "paper_title": "TransAct: Transformer-based Realtime User Action Model for Recommendation at Pinterest",
+      "paper_url": "https://arxiv.org/abs/2306.00248",
+      "year": 2023,
+      "venue": "KDD",
+      "category": "sequence",
+      "one_liner": "Transformer over recent real-time user actions fused with batch (long-term) features; an industrial behavior-sequence model in the DIN/BST family.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": null,
+      "difficulty": "medium",
+      "status": "candidate"
+    },
+    {
+      "name": "TWIN",
+      "paper_title": "TWIN: Two-stage Interest Network for Lifelong User Behavior Modeling in CTR Prediction at Kuaishou",
+      "paper_url": "https://arxiv.org/abs/2302.02352",
+      "year": 2023,
+      "venue": "KDD",
+      "category": "sequence",
+      "one_liner": "Two-stage target-attention (GSU+ESU) over lifelong behavior sequences with consistent relevance metrics across stages; for very long user histories.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": null,
+      "difficulty": "hard",
+      "status": "candidate"
     }
   ]
 }

--- a/benchmarks/onboard/candidates.json
+++ b/benchmarks/onboard/candidates.json
@@ -102,7 +102,7 @@
       "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
       "paper_metric": null,
       "difficulty": "medium",
-      "status": "candidate"
+      "status": "implemented"
     },
     {
       "name": "FCN",

--- a/benchmarks/onboard/candidates.json
+++ b/benchmarks/onboard/candidates.json
@@ -1,0 +1,82 @@
+{
+  "_schema": {
+    "name": "model name (CapWords, used as the deepctr.models symbol)",
+    "paper_title": "full paper title",
+    "paper_url": "link to the paper",
+    "year": "publication year",
+    "venue": "venue (KDD/RecSys/AAAI/...)",
+    "category": "single | sequence | multitask",
+    "one_liner": "one-sentence description of the key idea",
+    "ref_impl_url": "reference implementation (e.g. FuxiCTR/BARS) if any",
+    "paper_metric": "reported metric, e.g. {\"dataset\": \"Criteo_x1\", \"AUC\": 0.8137}",
+    "difficulty": "easy | medium | hard (DeepCTR integration effort)",
+    "status": "candidate | implemented | skipped"
+  },
+  "candidates": [
+    {
+      "name": "OneTrans",
+      "paper_title": "OneTrans: Unified Feature Interaction and Sequence Modeling with One Transformer in Industrial Recommender Systems",
+      "paper_url": "",
+      "year": 2024,
+      "venue": "industrial",
+      "category": "sequence",
+      "one_liner": "Feeds feature-field tokens and behavior-sequence tokens into one Transformer with a structured mask so feature interaction and sequence modeling happen jointly.",
+      "ref_impl_url": "",
+      "paper_metric": null,
+      "difficulty": "hard",
+      "status": "implemented"
+    },
+    {
+      "name": "FinalMLP",
+      "paper_title": "FinalMLP: An Enhanced Two-Stream MLP Model for CTR Prediction",
+      "paper_url": "https://arxiv.org/abs/2304.00902",
+      "year": 2023,
+      "venue": "AAAI",
+      "category": "single",
+      "one_liner": "Two parallel MLP streams with per-stream feature gating, fused by a multi-head bilinear interaction aggregation head; a simple MLP-only model that rivals complex interaction nets.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": {"dataset": "Criteo_x1", "AUC": 0.8137},
+      "difficulty": "easy",
+      "status": "candidate"
+    },
+    {
+      "name": "MaskNet",
+      "paper_title": "MaskNet: Introducing Feature-Wise Multiplication to CTR Ranking Models by Instance-Guided Mask",
+      "paper_url": "https://arxiv.org/abs/2102.07619",
+      "year": 2021,
+      "venue": "DLP-KDD",
+      "category": "single",
+      "one_liner": "Applies instance-guided multiplicative masks on feature embeddings / hidden layers (serial or parallel MaskBlocks) to inject feature-wise multiplicative interactions into an MLP.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": {"dataset": "Criteo_x1", "AUC": 0.8124},
+      "difficulty": "easy",
+      "status": "candidate"
+    },
+    {
+      "name": "GDCN",
+      "paper_title": "Towards Deeper, Lighter and Interpretable Cross Network for CTR Prediction",
+      "paper_url": "https://arxiv.org/abs/2311.04635",
+      "year": 2023,
+      "venue": "CIKM",
+      "category": "single",
+      "one_liner": "Gated Deep & Cross Network: adds an information gate to each cross layer of DCN-V2 to filter noisy high-order interactions.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": {"dataset": "Criteo_x1", "AUC": 0.8138},
+      "difficulty": "medium",
+      "status": "candidate"
+    },
+    {
+      "name": "EulerNet",
+      "paper_title": "EulerNet: Adaptive Feature Interaction Learning via Euler's Formula for CTR Prediction",
+      "paper_url": "https://arxiv.org/abs/2304.10711",
+      "year": 2023,
+      "venue": "SIGIR",
+      "category": "single",
+      "one_liner": "Learns arbitrary-order feature interactions in a complex vector space via Euler's formula, modeling exponents of interactions as learnable parameters.",
+      "ref_impl_url": "https://github.com/reczoo/FuxiCTR",
+      "paper_metric": {"dataset": "Criteo_x1", "AUC": 0.8137},
+      "difficulty": "hard",
+      "status": "candidate"
+    }
+  ]
+}

--- a/benchmarks/onboard/discover.py
+++ b/benchmarks/onboard/discover.py
@@ -5,8 +5,8 @@ industry/academic CTR models, each with a fixed schema (paper, venue, category,
 key idea, reference impl, reported metric, integration difficulty, status).
 
   discover --list                list candidates (optionally filtered)
-  discover --refresh             print a research prompt to refresh the KB via
-                                 web search / the deep-research skill
+  discover --refresh             print a research prompt to refresh the KB
+                                 using your own web-search capability
 
 Discovery cannot fully auto-select models (that needs judgement), so the CLI
 automates the structured/ranked part and marks which candidates are already
@@ -26,8 +26,9 @@ DIFFICULTY_RANK = {"easy": 0, "medium": 1, "hard": 2}
 RESEARCH_PROMPT = """\
 Refresh benchmarks/onboard/candidates.json with recent CTR / recommendation models.
 
-Search these sources for models published in the last ~3 years that fit DeepCTR's
-feature-column interface (SparseFeat / DenseFeat / VarLenSparseFeat):
+Using your web-search / browsing capability, search these sources for models
+published in the last ~3 years that fit DeepCTR's feature-column interface
+(SparseFeat / DenseFeat / VarLenSparseFeat):
   - arXiv (cs.IR / cs.LG), Papers-with-Code CTR leaderboards
   - KDD / RecSys / CIKM / SIGIR / WWW / AAAI proceedings
   - FuxiCTR / BARS benchmark model zoo (github.com/reczoo/FuxiCTR)

--- a/benchmarks/onboard/discover.py
+++ b/benchmarks/onboard/discover.py
@@ -1,0 +1,93 @@
+"""Stage 1 - discover candidate models.
+
+Maintains a version-controlled knowledge base (``candidates.json``) of recent
+industry/academic CTR models, each with a fixed schema (paper, venue, category,
+key idea, reference impl, reported metric, integration difficulty, status).
+
+  discover --list                list candidates (optionally filtered)
+  discover --refresh             print a research prompt to refresh the KB via
+                                 web search / the deep-research skill
+
+Discovery cannot fully auto-select models (that needs judgement), so the CLI
+automates the structured/ranked part and marks which candidates are already
+implemented by cross-referencing the live deepctr.models packages.
+"""
+from __future__ import absolute_import, division, print_function
+
+import json
+import os
+
+from ._util import discover_models
+
+CANDIDATES_PATH = os.path.join(os.path.dirname(__file__), "candidates.json")
+
+DIFFICULTY_RANK = {"easy": 0, "medium": 1, "hard": 2}
+
+RESEARCH_PROMPT = """\
+Refresh benchmarks/onboard/candidates.json with recent CTR / recommendation models.
+
+Search these sources for models published in the last ~3 years that fit DeepCTR's
+feature-column interface (SparseFeat / DenseFeat / VarLenSparseFeat):
+  - arXiv (cs.IR / cs.LG), Papers-with-Code CTR leaderboards
+  - KDD / RecSys / CIKM / SIGIR / WWW / AAAI proceedings
+  - FuxiCTR / BARS benchmark model zoo (github.com/reczoo/FuxiCTR)
+
+For each new model emit one JSON object with this schema and append it under
+"candidates" (skip ones already present; keep existing "status"):
+  name, paper_title, paper_url, year, venue, category(single|sequence|multitask),
+  one_liner, ref_impl_url, paper_metric({dataset, AUC}), difficulty, status="candidate".
+
+Rank by: interface fit > reported AUC on Criteo_x1/Avazu > citation count, and
+prefer models NOT already in deepctr.models.
+"""
+
+
+def load_candidates():
+    with open(CANDIDATES_PATH, "r", encoding="utf-8") as f:
+        return json.load(f).get("candidates", [])
+
+
+def _implemented_names():
+    return set(discover_models())
+
+
+def run(args):
+    if getattr(args, "refresh", False):
+        print(RESEARCH_PROMPT)
+        print("After editing candidates.json, run: python -m benchmarks.onboard discover --list")
+        return 0
+
+    candidates = load_candidates()
+    implemented = _implemented_names()
+    # reconcile status against the live packages
+    for c in candidates:
+        if c["name"] in implemented:
+            c["status"] = "implemented"
+
+    cat = getattr(args, "category", None)
+    status = getattr(args, "status", None)
+    rows = [c for c in candidates
+            if (not cat or c.get("category") == cat)
+            and (not status or c.get("status") == status)]
+    # candidates first (not implemented), then by difficulty, then by paper AUC desc
+    def sort_key(c):
+        impl = c.get("status") == "implemented"
+        auc = (c.get("paper_metric") or {}).get("AUC", 0) or 0
+        return (impl, DIFFICULTY_RANK.get(c.get("difficulty"), 9), -auc)
+    rows.sort(key=sort_key)
+
+    cols = [("name", 12), ("category", 10), ("year", 5), ("venue", 9),
+            ("difficulty", 10), ("status", 12), ("AUC", 8)]
+    print("  ".join(h.ljust(w) for h, w in cols))
+    print("  ".join("-" * w for _h, w in cols))
+    for c in rows:
+        auc = (c.get("paper_metric") or {}).get("AUC", "")
+        vals = [c.get("name", ""), c.get("category", ""), str(c.get("year", "")),
+                c.get("venue", ""), c.get("difficulty", ""), c.get("status", ""), str(auc)]
+        print("  ".join(str(v).ljust(w) for v, (_h, w) in zip(vals, cols)))
+
+    todo = [c["name"] for c in rows if c.get("status") == "candidate"]
+    print()
+    print("%d candidate(s) not yet implemented: %s" % (len(todo), ", ".join(todo) or "-"))
+    print("Next: python -m benchmarks.onboard scaffold <Name> --category <cat>")
+    return 0

--- a/benchmarks/onboard/docs.py
+++ b/benchmarks/onboard/docs.py
@@ -1,0 +1,191 @@
+"""Stage 4 - update documentation for a model (idempotent, anchor-based).
+
+Touches:
+  - README.md                         : add a row to the model table
+  - docs/source/Features.md           : add a ### subsection in the right section
+  - docs/source/deepctr.models.rst    : add a toctree entry
+  - docs/source/deepctr.models.<...>.rst : create the autodoc stub
+  - docs/source/History.md            : add a dated changelog bullet
+  - benchmarks/RESULTS.md             : record the latest verify leaderboard line
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import re
+
+from . import REPO_ROOT
+from ._util import discover_models, read_text, write_text
+
+README = os.path.join(REPO_ROOT, "README.md")
+FEATURES = os.path.join(REPO_ROOT, "docs", "source", "Features.md")
+MODELS_RST = os.path.join(REPO_ROOT, "docs", "source", "deepctr.models.rst")
+DOCS_SRC = os.path.join(REPO_ROOT, "docs", "source")
+HISTORY = os.path.join(REPO_ROOT, "docs", "source", "History.md")
+RESULTS = os.path.join(REPO_ROOT, "benchmarks", "RESULTS.md")
+
+# where a ### subsection goes, by category: insert before this Features.md heading
+FEATURES_ANCHOR = {
+    "single": "## Sequence Models",
+    "sequence": "## MultiTask Models",
+    "multitask": "## Layers",
+}
+# rst module dotted path, by category
+RST_MODULE = {
+    "single": "deepctr.models.%s",
+    "sequence": "deepctr.models.sequence.%s",
+    "multitask": "deepctr.models.multitask.%s",
+}
+
+
+def _log(changed, msg):
+    print(("  [+] " if changed else "  [=] ") + msg)
+
+
+def _candidate_meta(name):
+    try:
+        from .discover import load_candidates
+        for c in load_candidates():
+            if c.get("name") == name:
+                return c
+    except Exception:
+        pass
+    return {}
+
+
+# --------------------------------------------------------------------------- #
+def _update_readme_table(name, venue, year, title, url):
+    text = read_text(README)
+    if re.search(r"\|\s*%s\s*\|" % re.escape(name), text):
+        _log(False, "README.md: table row")
+        return
+    lines = text.splitlines(keepends=True)
+    # find the model table header
+    hdr = next((i for i, l in enumerate(lines)
+                if "Model" in l and "Paper" in l and l.lstrip().startswith("|")), None)
+    if hdr is None:
+        _log(False, "README.md: no model table found (skipped)")
+        return
+    # last consecutive table row after the header/separator
+    i = hdr + 1
+    last = i
+    while i < len(lines) and lines[i].lstrip().startswith("|"):
+        last = i
+        i += 1
+    cite = "[%s %s][%s](%s)" % (venue or "", year or "", title or name, url or "")
+    row = "|   %s                   | %s   |\n" % (name, cite)
+    lines.insert(last + 1, row)
+    write_text(README, "".join(lines))
+    _log(True, "README.md: table row")
+
+
+def _update_features(name, category, one_liner, title, url):
+    text = read_text(FEATURES)
+    if re.search(r"^###\s+%s\b" % re.escape(name), text, re.MULTILINE):
+        _log(False, "Features.md: ### %s" % name)
+        return
+    anchor = FEATURES_ANCHOR[category]
+    block = ("### %s\n\n%s\n\n[%s](%s)\n\n"
+             % (name, one_liner or "TODO: description.", title or name, url or ""))
+    if anchor in text:
+        text = text.replace(anchor, block + anchor, 1)
+    else:
+        text = text.rstrip() + "\n\n" + block
+    write_text(FEATURES, text)
+    _log(True, "Features.md: ### %s" % name)
+
+
+def _update_rst(name, category):
+    lower = name.lower()
+    module = RST_MODULE[category] % lower
+    stub_path = os.path.join(DOCS_SRC, module + ".rst")
+    if os.path.exists(stub_path):
+        _log(False, "%s.rst exists" % module)
+    else:
+        title = "%s module" % module
+        underline = "=" * len(title)
+        stub = ("%s\n%s\n\n.. automodule:: %s\n    :members:\n"
+                "    :no-undoc-members:\n    :no-show-inheritance:\n"
+                % (title, underline, module))
+        write_text(stub_path, stub)
+        _log(True, "%s.rst created" % module)
+
+    # add to toctree in deepctr.models.rst
+    text = read_text(MODELS_RST)
+    entry = "   %s\n" % module
+    if entry in text:
+        _log(False, "deepctr.models.rst: toctree %s" % module)
+        return
+    lines = text.splitlines(keepends=True)
+    # insert after the last existing toctree model entry
+    last = next((i for i in range(len(lines) - 1, -1, -1)
+                 if lines[i].lstrip().startswith("deepctr.models.")), None)
+    if last is None:
+        _log(False, "deepctr.models.rst: no toctree found (skipped)")
+        return
+    lines.insert(last + 1, entry)
+    write_text(MODELS_RST, "".join(lines))
+    _log(True, "deepctr.models.rst: toctree %s" % module)
+
+
+def _update_history(name, date_str, anchor_slug):
+    text = read_text(HISTORY)
+    if re.search(r"Add \[%s\]" % re.escape(name), text):
+        _log(False, "History.md: changelog bullet")
+        return
+    lines = text.splitlines(keepends=True)
+    hidx = next((i for i, l in enumerate(lines) if l.strip() == "# History"), None)
+    bullet = ("- %s : Add [%s](./Features.html#%s) model via the onboarding pipeline.\n"
+              % (date_str, name, anchor_slug))
+    if hidx is None:
+        lines.insert(0, bullet)
+    else:
+        lines.insert(hidx + 1, bullet)
+    write_text(HISTORY, "".join(lines))
+    _log(True, "History.md: changelog bullet")
+
+
+def _update_results(name):
+    """Append the latest verify leaderboard line into a managed RESULTS section."""
+    from .verify import REPORTS_DIR
+    report = os.path.join(REPORTS_DIR, name + ".md")
+    if not os.path.exists(report):
+        _log(False, "RESULTS.md: no verify report yet (run verify first)")
+        return
+    marker = "<!-- onboard:results -->"
+    text = read_text(RESULTS) if os.path.exists(RESULTS) else "# Benchmark results\n"
+    if marker not in text:
+        text = text.rstrip() + ("\n\n## Onboarded via pipeline %s\n\n"
+                                "Auto-recorded verify outcomes for models added through "
+                                "`benchmarks.onboard`.\n\n" % marker)
+    line = "- **%s**: see `benchmarks/onboard/reports/%s.md`\n" % (name, name)
+    if line in text:
+        _log(False, "RESULTS.md: entry for %s" % name)
+        return
+    text = text.rstrip() + "\n" + line
+    write_text(RESULTS, text)
+    _log(True, "RESULTS.md: entry for %s" % name)
+
+
+def run(args):
+    name = args.name
+    category = getattr(args, "category", None) or discover_models().get(name, {}).get("category")
+    if not category:
+        raise SystemExit("unknown model %r; pass --category" % name)
+
+    meta = _candidate_meta(name)
+    title = args.paper_title or meta.get("paper_title", "")
+    url = args.paper_url or meta.get("paper_url", "")
+    one_liner = getattr(args, "one_liner", "") or meta.get("one_liner", "")
+    venue = meta.get("venue", "")
+    year = meta.get("year", "")
+    # anchor slug Sphinx generates from "### Name"
+    anchor_slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+    print("Updating docs for %s (%s)" % (name, category))
+    _update_readme_table(name, venue, year, title, url)
+    _update_features(name, category, one_liner, title, url)
+    _update_rst(name, category)
+    _update_history(name, "06/24/2026", anchor_slug)
+    _update_results(name)
+    print("Docs updated.")
+    return 0

--- a/benchmarks/onboard/reports/FinalMLP.md
+++ b/benchmarks/onboard/reports/FinalMLP.md
@@ -1,0 +1,14 @@
+# Verify report: FinalMLP
+
+- category: **single**
+- correctness:
+    - audit (fully wired): PASS
+    - unit test: PASS (2 passed, 3 warnings in 12.81s)
+- effectiveness (primary metric = AUC):
+    - DeepFM: AUC=0.5771 LogLoss=0.7297 [ok] (baseline)
+    - FinalMLP: AUC=0.4158 LogLoss=0.6827 [ok]  <- new model
+- paper-reported: {'dataset': 'Criteo_x1', 'AUC': 0.8137}
+
+## Verdict
+
+correctness PASS. FinalMLP AUC=0.4158; DeepFM baseline AUC=0.5771 (new model is below); paper AUC=0.8137.

--- a/benchmarks/onboard/reports/MaskNet.md
+++ b/benchmarks/onboard/reports/MaskNet.md
@@ -1,0 +1,14 @@
+# Verify report: MaskNet
+
+- category: **single**
+- correctness:
+    - audit (fully wired): PASS
+    - unit test: PASS (2 passed, 3 warnings in 18.14s)
+- effectiveness (primary metric = AUC):
+    - DeepFM: AUC=0.5771 LogLoss=0.7297 [ok] (baseline)
+    - MaskNet: AUC=0.552 LogLoss=0.526 [ok]  <- new model
+- paper-reported: {'dataset': 'Criteo_x1', 'AUC': 0.8124}
+
+## Verdict
+
+correctness PASS. MaskNet AUC=0.552; DeepFM baseline AUC=0.5771 (new model is below); paper AUC=0.8124.

--- a/benchmarks/onboard/reports/OneTrans.md
+++ b/benchmarks/onboard/reports/OneTrans.md
@@ -1,0 +1,12 @@
+# Verify report: OneTrans
+
+- category: **sequence**
+- correctness:
+    - audit (fully wired): PASS
+    - unit test: PASS (1 passed, 2 warnings in 10.16s)
+- effectiveness (primary metric = AUC):
+    - OneTrans: AUC=0.4735 LogLoss=0.708 [ok]  <- new model
+
+## Verdict
+
+correctness PASS. OneTrans AUC=0.4735.

--- a/benchmarks/onboard/reports/WuKong.md
+++ b/benchmarks/onboard/reports/WuKong.md
@@ -1,0 +1,13 @@
+# Verify report: WuKong
+
+- category: **single**
+- correctness:
+    - audit (fully wired): PASS
+    - unit test: PASS (2 passed, 3 warnings in 18.12s)
+- effectiveness (primary metric = AUC):
+    - DeepFM: AUC=0.5771 LogLoss=0.7297 [ok] (baseline)
+    - WuKong: AUC=0.5627 LogLoss=0.5764 [ok]  <- new model
+
+## Verdict
+
+correctness PASS. WuKong AUC=0.5627; DeepFM baseline AUC=0.5771 (new model is below).

--- a/benchmarks/onboard/scaffold.py
+++ b/benchmarks/onboard/scaffold.py
@@ -1,0 +1,200 @@
+"""Scaffold a new model and auto-wire every registration point.
+
+Eliminates the error-prone 6-point manual checklist that left OneTrans
+half-integrated. Generates model/test/layer skeletons from templates and edits
+all the __init__ / custom_objects / registry files idempotently.
+
+  scaffold <Name> --category single|sequence|multitask [--with-layer] [--wire-only]
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import re
+
+from . import REPO_ROOT
+from ._util import (
+    CATEGORY_INIT, CATEGORY_PKG_DIR, CATEGORY_REGISTRY, LAYERS_INIT, MODELS_INIT, REGISTRY_PY,
+    TESTS_MODELS_DIR, add_dict_entry, add_to_all, add_to_import_line, add_to_paren_import,
+    ensure_line, layers_custom_objects, read_text, write_text,
+)
+
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
+
+
+def _render(template_name, mapping):
+    text = read_text(os.path.join(TEMPLATE_DIR, template_name))
+    for k, v in mapping.items():
+        text = text.replace("{{%s}}" % k, v)
+    return text
+
+
+def _log(changed, msg):
+    print(("  [+] " if changed else "  [=] ") + msg)
+
+
+# --------------------------------------------------------------------------- #
+# Individual wiring steps
+# --------------------------------------------------------------------------- #
+def _wire_package_exports(name, category):
+    """Make ``from deepctr.models import <Name>`` work."""
+    lower = name.lower()
+    init = CATEGORY_INIT[category]
+    if category == "single":
+        changed = ensure_line(init, "from .%s import %s" % (lower, name),
+                              anchor="__all__ = [", after=False)
+        _log(changed, "deepctr/models/__init__.py: import %s" % name)
+    else:
+        # sub-package __init__ holds the definition import …
+        changed = ensure_line(init, "from .%s import %s" % (lower, name))
+        _log(changed, "deepctr/models/%s/__init__.py: import %s" % (category, name))
+        # … and the top-level package re-exports via the aggregate line.
+        changed = add_to_import_line(MODELS_INIT, category, name)
+        _log(changed, "deepctr/models/__init__.py: re-export %s from .%s" % (name, category))
+    changed = add_to_all(MODELS_INIT, name)
+    _log(changed, "deepctr/models/__init__.py: __all__ += %s" % name)
+
+
+def _wire_custom_objects(name, layer_symbols):
+    """Register layer classes in deepctr/layers/custom_objects."""
+    for sym in layer_symbols:
+        changed = add_dict_entry(LAYERS_INIT, "custom_objects", sym, sym)
+        _log(changed, "deepctr/layers/__init__.py: custom_objects['%s']" % sym)
+
+
+def _detect_model_layer_symbols(name, category):
+    """For --wire-only: find layer symbols this model needs that are already
+    imported in layers/__init__ but missing from custom_objects.
+
+    Matches by the layer module sharing the model stem (e.g. ``onetrans``).
+    """
+    lower = name.lower()
+    imported, registered = layers_custom_objects()
+    text = read_text(LAYERS_INIT)
+    # names imported from `.<lower>` module in layers/__init__
+    m = re.search(r"^from\s+\.%s\s+import\s+(.+)$" % re.escape(lower), text, re.MULTILINE)
+    syms = []
+    if m:
+        for tok in m.group(1).split(","):
+            tok = tok.strip()
+            if " as " in tok:
+                tok = tok.split(" as ")[-1].strip()
+            if tok and tok not in registered:
+                syms.append(tok)
+    return syms
+
+
+def _create_layer_file(name):
+    lower = name.lower()
+    path = os.path.join(REPO_ROOT, "deepctr", "layers", lower + ".py")
+    if os.path.exists(path):
+        _log(False, "deepctr/layers/%s.py exists" % lower)
+    else:
+        write_text(path, _render("layer.py.tmpl", {"NAME": name}))
+        _log(True, "deepctr/layers/%s.py created" % lower)
+    changed = ensure_line(LAYERS_INIT, "from .%s import %sLayer" % (lower, name),
+                          anchor="custom_objects = {", after=False)
+    _log(changed, "deepctr/layers/__init__.py: import %sLayer" % name)
+    return [name + "Layer"]
+
+
+def _create_model_file(name, category, mapping):
+    lower = name.lower()
+    pkg_dir = CATEGORY_PKG_DIR[category]
+    path = os.path.join(pkg_dir, lower + ".py")
+    if os.path.exists(path):
+        _log(False, "model file %s exists (skipped)" % os.path.relpath(path, REPO_ROOT))
+        return
+    template = {"single": "model_single.py.tmpl",
+                "sequence": "model_sequence.py.tmpl",
+                "multitask": "model_multitask.py.tmpl"}[category]
+    write_text(path, _render(template, mapping))
+    _log(True, "%s created" % os.path.relpath(path, REPO_ROOT))
+
+
+def _create_test_file(name, category):
+    path = os.path.join(TESTS_MODELS_DIR, name + "_test.py")
+    if os.path.exists(path):
+        _log(False, "tests/models/%s_test.py exists" % name)
+        return
+    template = {"single": "test_single.py.tmpl",
+                "sequence": "test_sequence.py.tmpl",
+                "multitask": "test_multitask.py.tmpl"}[category]
+    write_text(path, _render(template, {"NAME": name}))
+    _log(True, "tests/models/%s_test.py created" % name)
+
+
+def _wire_registry(name, category):
+    # 1) import the model symbol into benchmarks/registry.py
+    changed = add_to_paren_import(REGISTRY_PY, name, "deepctr.models")
+    _log(changed, "benchmarks/registry.py: import %s" % name)
+
+    # 2) add the builder entry
+    dict_name = CATEGORY_REGISTRY[category]
+    if category == "single":
+        expr = "lambda lin, dnn, task: %s(lin, dnn, task=task)" % name
+        changed = add_dict_entry(REGISTRY_PY, dict_name, name, expr)
+        _log(changed, "benchmarks/registry.py: %s['%s']" % (dict_name, name))
+    elif category == "multitask":
+        expr = "lambda dnn, types, names: %s(dnn, task_types=types, task_names=names)" % name
+        changed = add_dict_entry(REGISTRY_PY, dict_name, name, expr)
+        _log(changed, "benchmarks/registry.py: %s['%s']" % (dict_name, name))
+    else:  # sequence: needs a builder function + dict entry referencing it
+        _wire_sequence_builder(name)
+
+
+def _wire_sequence_builder(name):
+    lower = name.lower()
+    text = read_text(REGISTRY_PY)
+    builder = "_build_%s" % lower
+    if ("def %s(" % builder) not in text:
+        fn = (
+            "\ndef %s(data, task):\n"
+            "    # Transformer-style sequence model: pick head count that divides the\n"
+            "    # behavior embedding dim (see _build_bst / _build_dsin for the pattern).\n"
+            "    emb = _behavior_embedding_dim(data)\n"
+            "    head = _largest_divisor_leq(emb, 4)\n"
+            "    return %s(data.feature_columns, data.behavior_feature_list,\n"
+            "             %satt_head_num=head, task=task)\n\n\n"
+            % (builder, name, " " * len(name))
+        )
+        anchor = "SEQUENCE_MODELS = {"
+        idx = text.index(anchor)
+        text = text[:idx] + fn.lstrip("\n") + text[idx:]
+        write_text(REGISTRY_PY, text)
+        _log(True, "benchmarks/registry.py: %s()" % builder)
+    else:
+        _log(False, "benchmarks/registry.py: %s() exists" % builder)
+    expr = '{"view": "din", "build": %s}' % builder
+    changed = add_dict_entry(REGISTRY_PY, "SEQUENCE_MODELS", name, expr)
+    _log(changed, "benchmarks/registry.py: SEQUENCE_MODELS['%s']" % name)
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+def run(args):
+    name = args.name
+    category = args.category
+    paper = args.paper_title or "TODO: add paper citation."
+    mapping = {"NAME": name, "NAME_LOWER": name.lower(), "CATEGORY": category, "PAPER": paper}
+
+    print("Scaffolding %s (%s)%s" % (name, category, " [wire-only]" if args.wire_only else ""))
+
+    layer_symbols = []
+    if args.wire_only:
+        layer_symbols = _detect_model_layer_symbols(name, category)
+    else:
+        _create_model_file(name, category, mapping)
+        if args.with_layer:
+            layer_symbols = _create_layer_file(name)
+
+    _wire_package_exports(name, category)
+    if layer_symbols:
+        _wire_custom_objects(name, layer_symbols)
+    _create_test_file(name, category)
+    _wire_registry(name, category)
+
+    print("Done. Run:  python -m benchmarks.onboard audit --name %s" % name)
+    if not args.wire_only:
+        print("Next:  implement the TODO core, then `verify` and `docs`.")
+    return 0

--- a/benchmarks/onboard/scaffold.py
+++ b/benchmarks/onboard/scaffold.py
@@ -19,6 +19,7 @@ from ._util import (
 )
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
+TESTS_LAYERS_DIR = os.path.join(REPO_ROOT, "tests", "layers")
 
 
 def _render(template_name, mapping):
@@ -95,6 +96,16 @@ def _create_layer_file(name):
                           anchor="custom_objects = {", after=False)
     _log(changed, "deepctr/layers/__init__.py: import %sLayer" % name)
     return [name + "Layer"]
+
+
+def _create_layer_test(name):
+    path = os.path.join(TESTS_LAYERS_DIR, name + "_correctness_test.py")
+    if os.path.exists(path):
+        _log(False, "tests/layers/%s_correctness_test.py exists" % name)
+        return
+    mapping = {"NAME": name, "NAME_LOWER": name.lower()}
+    write_text(path, _render("test_layer_correctness.py.tmpl", mapping))
+    _log(True, "tests/layers/%s_correctness_test.py created" % name)
 
 
 def _create_model_file(name, category, mapping):
@@ -187,6 +198,7 @@ def run(args):
         _create_model_file(name, category, mapping)
         if args.with_layer:
             layer_symbols = _create_layer_file(name)
+            _create_layer_test(name)
 
     _wire_package_exports(name, category)
     if layer_symbols:

--- a/benchmarks/onboard/templates/layer.py.tmpl
+++ b/benchmarks/onboard/templates/layer.py.tmpl
@@ -1,0 +1,34 @@
+# -*- coding:utf-8 -*-
+"""Custom layer(s) for the {{NAME}} model."""
+
+import tensorflow as tf
+from tensorflow.keras.layers import Layer
+
+
+class {{NAME}}Layer(Layer):
+    """{{NAME}} core layer.
+
+    TODO: implement ``build`` (create weights) and ``call`` (forward pass).
+    Remember: every custom layer MUST be registered in
+    ``deepctr/layers/__init__.py`` ``custom_objects`` (scaffold does this for you)
+    or ``save_model``/``load_model`` will fail.
+    """
+
+    def __init__(self, **kwargs):
+        super({{NAME}}Layer, self).__init__(**kwargs)
+
+    def build(self, input_shape):
+        # TODO: create trainable weights with self.add_weight(...)
+        super({{NAME}}Layer, self).build(input_shape)
+
+    def call(self, inputs, **kwargs):
+        # TODO: implement the forward pass.
+        return inputs
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+    def get_config(self):
+        config = {}
+        base_config = super({{NAME}}Layer, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/benchmarks/onboard/templates/model_multitask.py.tmpl
+++ b/benchmarks/onboard/templates/model_multitask.py.tmpl
@@ -1,0 +1,53 @@
+# -*- coding:utf-8 -*-
+"""
+{{NAME}}
+
+Reference:
+    {{PAPER}}
+"""
+
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
+
+from ...feature_column import build_input_features, input_from_feature_columns
+from ...layers.core import PredictionLayer, DNN
+from ...layers.utils import combined_dnn_input
+
+
+def {{NAME}}(dnn_feature_columns, tower_dnn_hidden_units=(64,), l2_reg_embedding=0.00001, l2_reg_dnn=0,
+        seed=1024, dnn_dropout=0, dnn_activation='relu', dnn_use_bn=False,
+        task_types=('binary', 'binary'), task_names=('ctr', 'ctcvr')):
+    """Instantiates the {{NAME}} multi-task architecture.
+
+    :param dnn_feature_columns: iterable of all feature columns used by the model.
+    :param tower_dnn_hidden_units: layer sizes of each per-task tower DNN.
+    :param task_types: list of ``"binary"``/``"regression"``, one per task.
+    :param task_names: list of str, the prediction name of each task.
+    :return: A Keras model instance with one output per task.
+    """
+    num_tasks = len(task_names)
+    if num_tasks != len(task_types):
+        raise ValueError("task_names and task_types must have the same length")
+
+    features = build_input_features(dnn_feature_columns)
+    inputs_list = list(features.values())
+
+    sparse_embedding_list, dense_value_list = input_from_feature_columns(
+        features, dnn_feature_columns, l2_reg_embedding, seed)
+    dnn_input = combined_dnn_input(sparse_embedding_list, dense_value_list)
+
+    # ===================== TODO: {{NAME}} core multi-task body =====================
+    # Implement the shared/expert/gating structure here, producing one tower input
+    # per task. The skeleton below shares a single body across tasks.
+    shared = DNN((128,), dnn_activation, l2_reg_dnn, dnn_dropout, dnn_use_bn, seed=seed)(dnn_input)
+    # =========================== END TODO ==========================================
+
+    task_outs = []
+    for task_type, task_name in zip(task_types, task_names):
+        tower = DNN(tower_dnn_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout,
+                    dnn_use_bn, seed=seed, name='tower_' + task_name)(shared)
+        logit = Dense(1, use_bias=False)(tower)
+        task_outs.append(PredictionLayer(task_type, name=task_name)(logit))
+
+    model = Model(inputs=inputs_list, outputs=task_outs)
+    return model

--- a/benchmarks/onboard/templates/model_sequence.py.tmpl
+++ b/benchmarks/onboard/templates/model_sequence.py.tmpl
@@ -1,0 +1,55 @@
+# -*- coding:utf-8 -*-
+"""
+{{NAME}}
+
+Reference:
+    {{PAPER}}
+"""
+
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
+
+from ...feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, build_input_features
+from ...inputs import create_embedding_matrix, embedding_lookup, get_dense_input, varlen_embedding_lookup
+from ...layers.core import DNN, PredictionLayer
+from ...layers.sequence import AttentionSequencePoolingLayer
+from ...layers.utils import concat_func, combined_dnn_input
+
+
+def {{NAME}}(dnn_feature_columns, history_feature_list, dnn_hidden_units=(256, 128, 64),
+        dnn_activation='relu', dnn_dropout=0.0, dnn_use_bn=False,
+        l2_reg_embedding=1e-6, l2_reg_dnn=0, seed=1024, task='binary'):
+    """Instantiates the {{NAME}} sequence model.
+
+    :param dnn_feature_columns: iterable of all feature columns (SparseFeat / VarLenSparseFeat / DenseFeat).
+    :param history_feature_list: list of str, names of target sparse features whose
+        behavior-sequence counterparts (prefixed with ``"hist_"``) are VarLenSparseFeat columns.
+    :param task: ``"binary"`` or ``"regression"``.
+    :return: A Keras model instance.
+    """
+    features = build_input_features(dnn_feature_columns)
+    inputs_list = list(features.values())
+
+    sparse_feature_columns = [fc for fc in dnn_feature_columns if isinstance(fc, SparseFeat)]
+    dense_feature_columns = [fc for fc in dnn_feature_columns if isinstance(fc, DenseFeat)]
+    varlen_feature_columns = [fc for fc in dnn_feature_columns if isinstance(fc, VarLenSparseFeat)]
+
+    embedding_dict = create_embedding_matrix(dnn_feature_columns, l2_reg_embedding, seed, prefix="",
+                                             seq_mask_zero=True)
+
+    dense_value_list = get_dense_input(features, dense_feature_columns)
+
+    # ===================== TODO: {{NAME}} core sequence modeling =====================
+    # Use embedding_lookup / varlen_embedding_lookup to gather target & history
+    # embeddings, model the behavior sequence (attention / transformer / GRU), and
+    # build `dnn_input` from the pooled representation + other feature embeddings.
+    sparse_emb_list = embedding_lookup(embedding_dict, features, sparse_feature_columns, to_list=True)
+    dnn_input = combined_dnn_input(sparse_emb_list, dense_value_list)
+    # =========================== END TODO ============================================
+
+    dnn_out = DNN(dnn_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout, dnn_use_bn, seed=seed)(dnn_input)
+    final_logit = Dense(1, use_bias=False)(dnn_out)
+    output = PredictionLayer(task)(final_logit)
+
+    model = Model(inputs=inputs_list, outputs=output)
+    return model

--- a/benchmarks/onboard/templates/model_single.py.tmpl
+++ b/benchmarks/onboard/templates/model_single.py.tmpl
@@ -1,0 +1,59 @@
+# -*- coding:utf-8 -*-
+"""
+{{NAME}}
+
+Reference:
+    {{PAPER}}
+"""
+
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense
+
+from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
+from ..layers.core import PredictionLayer, DNN
+from ..layers.utils import add_func, combined_dnn_input
+
+
+def {{NAME}}(linear_feature_columns, dnn_feature_columns, dnn_hidden_units=(256, 128, 64),
+        l2_reg_linear=0.00001, l2_reg_embedding=0.00001, l2_reg_dnn=0, seed=1024, dnn_dropout=0,
+        dnn_activation='relu', dnn_use_bn=False, task='binary'):
+    """Instantiates the {{NAME}} architecture.
+
+    :param linear_feature_columns: An iterable containing all the features used by the linear part of the model.
+    :param dnn_feature_columns: An iterable containing all the features used by the deep part of the model.
+    :param dnn_hidden_units: list, layer number and units in each layer of the DNN.
+    :param l2_reg_linear: float. L2 regularizer strength applied to the linear part.
+    :param l2_reg_embedding: float. L2 regularizer strength applied to embedding vectors.
+    :param l2_reg_dnn: float. L2 regularizer strength applied to the DNN.
+    :param seed: integer, random seed.
+    :param dnn_dropout: float in [0,1), dropout probability for the DNN.
+    :param dnn_activation: activation function used in the DNN.
+    :param dnn_use_bn: bool. Whether to use BatchNormalization in the DNN.
+    :param task: ``"binary"`` for binary logloss or ``"regression"`` for regression loss.
+    :return: A Keras model instance.
+    """
+    features = build_input_features(linear_feature_columns + dnn_feature_columns)
+    inputs_list = list(features.values())
+
+    linear_logit = get_linear_logit(features, linear_feature_columns, seed=seed, prefix='linear',
+                                    l2_reg=l2_reg_linear)
+
+    sparse_embedding_list, dense_value_list = input_from_feature_columns(
+        features, dnn_feature_columns, l2_reg_embedding, seed)
+
+    dnn_input = combined_dnn_input(sparse_embedding_list, dense_value_list)
+
+    # ===================== TODO: {{NAME}} core interaction =====================
+    # Implement the model-specific feature interaction here. Reuse layers from
+    # deepctr.layers.interaction (FM, CrossNet, InteractingLayer, CIN, ...) and/or
+    # add a custom layer in deepctr/layers/{{NAME_LOWER}}.py (scaffold --with-layer).
+    # Produce `dnn_logit` (and optionally an extra interaction logit to add in).
+    dnn_out = DNN(dnn_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout, dnn_use_bn, seed=seed)(dnn_input)
+    dnn_logit = Dense(1, use_bias=False)(dnn_out)
+    # =========================== END TODO ======================================
+
+    final_logit = add_func([linear_logit, dnn_logit])
+    output = PredictionLayer(task)(final_logit)
+
+    model = Model(inputs=inputs_list, outputs=output)
+    return model

--- a/benchmarks/onboard/templates/test_layer_correctness.py.tmpl
+++ b/benchmarks/onboard/templates/test_layer_correctness.py.tmpl
@@ -1,0 +1,26 @@
+"""Semantic correctness contract for ``{{NAME}}Layer``.
+
+Keep the reference independent: translate the paper equation to NumPy rather
+than calling the implementation under test.  Add domain invariants with
+``assert_invariant`` when the layer has masking, causality, symmetry, or another
+property that should hold for every set of weights.
+"""
+import numpy as np
+
+from deepctr.layers.{{NAME_LOWER}} import {{NAME}}Layer
+from tests.correctness import assert_finite_gradients, assert_forward_matches
+
+
+def _reference(inputs, weights):
+    # TODO: replace this identity with an independent NumPy implementation of
+    # the paper equation when {{NAME}}Layer.call() is implemented.
+    return inputs
+
+
+def test_{{NAME}}Layer_reference_and_gradients():
+    inputs = np.asarray([[0.2, -0.1, 0.5],
+                         [0.4, 0.3, -0.2]], dtype="float32")
+    layer = {{NAME}}Layer()
+
+    assert_forward_matches(layer, inputs, _reference)
+    assert_finite_gradients(layer, inputs)

--- a/benchmarks/onboard/templates/test_multitask.py.tmpl
+++ b/benchmarks/onboard/templates/test_multitask.py.tmpl
@@ -1,0 +1,15 @@
+from deepctr.models import {{NAME}}
+from ..utils_mtl import get_mtl_test_data, check_mtl_model
+
+
+def test_{{NAME}}():
+    model_name = "{{NAME}}"
+    x, y_list, dnn_feature_columns = get_mtl_test_data()
+
+    model = {{NAME}}(dnn_feature_columns, tower_dnn_hidden_units=(8,),
+                 task_types=['binary', 'binary'], task_names=['label_income', 'label_marital'])
+    check_mtl_model(model, model_name, x, y_list, task_types=['binary', 'binary'])
+
+
+if __name__ == "__main__":
+    pass

--- a/benchmarks/onboard/templates/test_multitask.py.tmpl
+++ b/benchmarks/onboard/templates/test_multitask.py.tmpl
@@ -1,9 +1,11 @@
 from deepctr.models import {{NAME}}
+from tests.correctness import set_test_seed
 from ..utils_mtl import get_mtl_test_data, check_mtl_model
 
 
 def test_{{NAME}}():
     model_name = "{{NAME}}"
+    set_test_seed(2020)
     x, y_list, dnn_feature_columns = get_mtl_test_data()
 
     model = {{NAME}}(dnn_feature_columns, tower_dnn_hidden_units=(8,),

--- a/benchmarks/onboard/templates/test_sequence.py.tmpl
+++ b/benchmarks/onboard/templates/test_sequence.py.tmpl
@@ -2,6 +2,7 @@ import numpy as np
 
 from deepctr.feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, get_feature_names
 from deepctr.models import {{NAME}}
+from tests.correctness import set_test_seed
 from ..utils import check_model
 
 # NOTE: this model concatenates feature tokens with sequence tokens, so every
@@ -46,6 +47,7 @@ def get_xy_fd():
 
 def test_{{NAME}}():
     model_name = "{{NAME}}"
+    set_test_seed(2020)
     x, y, feature_columns, behavior_feature_list = get_xy_fd()
     model = {{NAME}}(feature_columns, behavior_feature_list,
                  dnn_hidden_units=[4, 4], att_head_num=2)

--- a/benchmarks/onboard/templates/test_sequence.py.tmpl
+++ b/benchmarks/onboard/templates/test_sequence.py.tmpl
@@ -1,0 +1,56 @@
+import numpy as np
+
+from deepctr.feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, get_feature_names
+from deepctr.models import {{NAME}}
+from ..utils import check_model
+
+# NOTE: this model concatenates feature tokens with sequence tokens, so every
+# sparse / history feature must share the SAME embedding_dim.
+EMB = 8
+
+
+def get_xy_fd():
+    feature_columns = [
+        SparseFeat('user', 3, embedding_dim=EMB),
+        SparseFeat('gender', 2, embedding_dim=EMB),
+        SparseFeat('item_id', 3 + 1, embedding_dim=EMB),
+        SparseFeat('cate_id', 2 + 1, embedding_dim=EMB),
+        DenseFeat('pay_score', 1),
+    ]
+    feature_columns += [
+        VarLenSparseFeat(SparseFeat('hist_item_id', vocabulary_size=3 + 1, embedding_dim=EMB,
+                                    embedding_name='item_id'), maxlen=4, length_name="seq_length"),
+        VarLenSparseFeat(SparseFeat('hist_cate_id', vocabulary_size=2 + 1, embedding_dim=EMB,
+                                    embedding_name='cate_id'), maxlen=4, length_name="seq_length"),
+    ]
+    # History behavior sequence feature name must start with "hist_".
+    behavior_feature_list = ["item_id", "cate_id"]
+
+    uid = np.array([0, 1, 2])
+    ugender = np.array([0, 1, 0])
+    iid = np.array([1, 2, 3])       # 0 is the mask value
+    cate_id = np.array([1, 2, 2])   # 0 is the mask value
+    pay_score = np.array([0.1, 0.2, 0.3])
+
+    hist_iid = np.array([[1, 2, 3, 0], [3, 2, 1, 0], [1, 2, 0, 0]])
+    hist_cate_id = np.array([[1, 2, 2, 0], [2, 2, 1, 0], [1, 2, 0, 0]])
+    seq_length = np.array([3, 3, 2])  # actual length of each behavior sequence
+
+    feature_dict = {'user': uid, 'gender': ugender, 'item_id': iid, 'cate_id': cate_id,
+                    'hist_item_id': hist_iid, 'hist_cate_id': hist_cate_id,
+                    'pay_score': pay_score, 'seq_length': seq_length}
+    x = {name: feature_dict[name] for name in get_feature_names(feature_columns)}
+    y = np.array([1, 0, 1])
+    return x, y, feature_columns, behavior_feature_list
+
+
+def test_{{NAME}}():
+    model_name = "{{NAME}}"
+    x, y, feature_columns, behavior_feature_list = get_xy_fd()
+    model = {{NAME}}(feature_columns, behavior_feature_list,
+                 dnn_hidden_units=[4, 4], att_head_num=2)
+    check_model(model, model_name, x, y)
+
+
+if __name__ == "__main__":
+    pass

--- a/benchmarks/onboard/templates/test_single.py.tmpl
+++ b/benchmarks/onboard/templates/test_single.py.tmpl
@@ -1,0 +1,24 @@
+import pytest
+
+from deepctr.models import {{NAME}}
+from ..utils import check_model, get_test_data, SAMPLE_SIZE
+
+
+@pytest.mark.parametrize(
+    'hidden_size,sparse_feature_num',
+    [((2,), 1),
+     ((3,), 2)]
+)
+def test_{{NAME}}(hidden_size, sparse_feature_num):
+    model_name = "{{NAME}}"
+    sample_size = SAMPLE_SIZE
+    x, y, feature_columns = get_test_data(sample_size, sparse_feature_num=sparse_feature_num,
+                                          dense_feature_num=sparse_feature_num)
+
+    model = {{NAME}}(feature_columns, feature_columns, dnn_hidden_units=hidden_size, dnn_dropout=0.5)
+
+    check_model(model, model_name, x, y)
+
+
+if __name__ == "__main__":
+    pass

--- a/benchmarks/onboard/templates/test_single.py.tmpl
+++ b/benchmarks/onboard/templates/test_single.py.tmpl
@@ -1,6 +1,7 @@
 import pytest
 
 from deepctr.models import {{NAME}}
+from tests.correctness import set_test_seed
 from ..utils import check_model, get_test_data, SAMPLE_SIZE
 
 
@@ -11,6 +12,7 @@ from ..utils import check_model, get_test_data, SAMPLE_SIZE
 )
 def test_{{NAME}}(hidden_size, sparse_feature_num):
     model_name = "{{NAME}}"
+    set_test_seed(2020)
     sample_size = SAMPLE_SIZE
     x, y, feature_columns = get_test_data(sample_size, sparse_feature_num=sparse_feature_num,
                                           dense_feature_num=sparse_feature_num)

--- a/benchmarks/onboard/verify.py
+++ b/benchmarks/onboard/verify.py
@@ -1,0 +1,187 @@
+"""Validate a model two ways:
+
+  correctness   - the model's unit test passes (compile / train / save+load
+                  round-trip) AND `audit` reports it fully wired.
+  effectiveness - a benchmark run trains it on data and its AUC is compared
+                  against an in-track baseline (and the paper number if known).
+
+Writes a Markdown report to benchmarks/onboard/reports/<name>.md.
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import subprocess
+import sys
+
+from . import REPO_ROOT
+from ._util import discover_models, test_file_for
+
+REPORTS_DIR = os.path.join(os.path.dirname(__file__), "reports")
+# Transient benchmark leaderboards go to the gitignored results dir, keeping
+# only the curated verify reports under REPORTS_DIR.
+BENCH_OUT_DIR = os.path.join(REPO_ROOT, "benchmarks", "results")
+
+TRACK_PRIMARY = {"single": "AUC", "sequence": "AUC", "multitask": "mean_AUC"}
+DEFAULT_BASELINE = {"single": "DeepFM", "sequence": "DIN", "multitask": "SharedBottom"}
+
+
+def _resolve_category(name, explicit):
+    if explicit:
+        return explicit
+    info = discover_models().get(name)
+    if not info:
+        raise SystemExit("unknown model %r; pass --category" % name)
+    return info["category"]
+
+
+# --------------------------------------------------------------------------- #
+# Correctness
+# --------------------------------------------------------------------------- #
+def _run_correctness(name):
+    result = {"audit": None, "unit_test": None}
+
+    from .audit import audit_models, _row_ok
+    rows, _ = audit_models(only={name})
+    result["audit"] = bool(rows) and _row_ok(rows[0])
+    result["audit_row"] = rows[0] if rows else None
+
+    test_path = test_file_for(name)
+    if not test_path:
+        result["unit_test"] = False
+        result["unit_test_note"] = "no test file found"
+        return result
+
+    env = dict(os.environ, CUDA_VISIBLE_DEVICES="", TF_USE_LEGACY_KERAS="1")
+    print("  running unit test: %s" % os.path.relpath(test_path, REPO_ROOT))
+    proc = subprocess.run([sys.executable, "-m", "pytest", test_path, "-q"],
+                          cwd=REPO_ROOT, env=env,
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out = proc.stdout.decode("utf-8", "replace")
+    result["unit_test"] = proc.returncode == 0
+    # keep the pytest summary line(s)
+    tail = [l for l in out.splitlines() if "passed" in l or "failed" in l or "error" in l.lower()]
+    result["unit_test_note"] = tail[-1].strip() if tail else "see output"
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Effectiveness
+# --------------------------------------------------------------------------- #
+def _run_benchmark(name, category, args):
+    from benchmarks import benchmark
+
+    track = category
+    baseline = args.baseline if args.baseline and args.baseline != name else DEFAULT_BASELINE[category]
+    if baseline == name:
+        baseline = None
+
+    models = name if baseline is None else "%s,%s" % (name, baseline)
+    argv = ["--track", track, "--models", models,
+            "--epochs", str(args.epochs), "--batch-size", str(args.batch_size),
+            "--val-split", "0", "--output-dir", BENCH_OUT_DIR]
+    if args.data_path:
+        argv += ["--data-path", args.data_path]
+        if category == "sequence":
+            argv += ["--seq-source", "movielens"]
+    elif category == "sequence":
+        argv += ["--n-samples", "400" if args.quick else "1200"]
+
+    print("  benchmark: python -m benchmarks.benchmark %s" % " ".join(argv))
+    bargs = benchmark.build_parser().parse_args(argv)
+    runner = {"single": benchmark.run_single,
+              "sequence": benchmark.run_sequence,
+              "multitask": benchmark.run_multitask}[track]
+    results = runner(bargs)
+    by_name = {r.model: r for r in results}
+    return by_name, baseline
+
+
+# --------------------------------------------------------------------------- #
+# Report
+# --------------------------------------------------------------------------- #
+def _paper_metric(name):
+    try:
+        from .discover import load_candidates
+        for c in load_candidates():
+            if c.get("name") == name:
+                return c.get("paper_metric")
+    except Exception:
+        pass
+    return None
+
+
+def _write_report(name, category, correctness, bench, baseline, verdict):
+    if not os.path.isdir(REPORTS_DIR):
+        os.makedirs(REPORTS_DIR)
+    primary = TRACK_PRIMARY[category]
+    lines = ["# Verify report: %s" % name, "",
+             "- category: **%s**" % category,
+             "- correctness:",
+             "    - audit (fully wired): %s" % ("PASS" if correctness["audit"] else "FAIL"),
+             "    - unit test: %s (%s)" % ("PASS" if correctness["unit_test"] else "FAIL",
+                                           correctness.get("unit_test_note", "")),
+             "- effectiveness (primary metric = %s):" % primary]
+    if bench is not None:
+        for mname, r in bench.items():
+            tag = "  <- new model" if mname == name else (" (baseline)" if mname == baseline else "")
+            metrics = " ".join("%s=%s" % (k, v) for k, v in r.metrics.items()) if r.metrics else r.note
+            lines.append("    - %s: %s [%s]%s" % (mname, metrics, r.status, tag))
+    paper = _paper_metric(name)
+    if paper:
+        lines.append("- paper-reported: %s" % paper)
+    lines += ["", "## Verdict", "", verdict, ""]
+    path = os.path.join(REPORTS_DIR, name + ".md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    return path
+
+
+def _make_verdict(name, category, correctness, bench, baseline):
+    primary = TRACK_PRIMARY[category]
+    ok = correctness["audit"] and correctness["unit_test"]
+    parts = []
+    parts.append("correctness %s" % ("PASS" if ok else "FAIL"))
+    if bench is not None and name in bench and bench[name].status == "ok":
+        new_auc = bench[name].metrics.get(primary)
+        msg = "%s %s=%s" % (name, primary, new_auc)
+        if baseline and baseline in bench and bench[baseline].status == "ok":
+            base_auc = bench[baseline].metrics.get(primary)
+            rel = "above" if (new_auc or 0) >= (base_auc or 0) else "below"
+            msg += "; %s baseline %s=%s (new model is %s)" % (baseline, primary, base_auc, rel)
+        paper = _paper_metric(name)
+        if paper and isinstance(paper, dict) and paper.get("AUC"):
+            msg += "; paper AUC=%s" % paper["AUC"]
+        parts.append(msg)
+    elif bench is not None:
+        parts.append("benchmark did not produce a metric for %s" % name)
+    return ". ".join(parts) + "."
+
+
+def run(args):
+    name = args.name
+    category = _resolve_category(name, getattr(args, "category", None))
+    print("Verifying %s (%s)" % (name, category))
+
+    print("\n[1/2] correctness")
+    correctness = _run_correctness(name)
+    print("  audit: %s | unit test: %s"
+          % ("PASS" if correctness["audit"] else "FAIL",
+             "PASS" if correctness["unit_test"] else "FAIL"))
+
+    bench, baseline = None, None
+    if getattr(args, "skip_benchmark", False):
+        print("\n[2/2] effectiveness: skipped (--skip-benchmark)")
+    else:
+        print("\n[2/2] effectiveness")
+        try:
+            bench, baseline = _run_benchmark(name, category, args)
+        except Exception as e:
+            print("  benchmark failed: %s" % e)
+
+    verdict = _make_verdict(name, category, correctness, bench, baseline)
+    path = _write_report(name, category, correctness, bench, baseline, verdict)
+    print("\nVerdict: %s" % verdict)
+    print("Report: %s" % os.path.relpath(path, REPO_ROOT))
+
+    passed = correctness["audit"] and correctness["unit_test"]
+    return 0 if passed else 1

--- a/benchmarks/onboard/verify.py
+++ b/benchmarks/onboard/verify.py
@@ -51,13 +51,21 @@ def _run_correctness(name):
         result["unit_test_note"] = "no test file found"
         return result
 
+    test_paths = [test_path]
+    layer_contract = os.path.join(REPO_ROOT, "tests", "layers",
+                                  name + "_correctness_test.py")
+    if os.path.exists(layer_contract):
+        test_paths.append(layer_contract)
+
     env = dict(os.environ, CUDA_VISIBLE_DEVICES="", TF_USE_LEGACY_KERAS="1")
-    print("  running unit test: %s" % os.path.relpath(test_path, REPO_ROOT))
-    proc = subprocess.run([sys.executable, "-m", "pytest", test_path, "-q"],
+    print("  running correctness tests: %s" %
+          ", ".join(os.path.relpath(path, REPO_ROOT) for path in test_paths))
+    proc = subprocess.run([sys.executable, "-m", "pytest"] + test_paths + ["-q"],
                           cwd=REPO_ROOT, env=env,
                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out = proc.stdout.decode("utf-8", "replace")
     result["unit_test"] = proc.returncode == 0
+    result["test_paths"] = test_paths
     # keep the pytest summary line(s)
     tail = [l for l in out.splitlines() if "passed" in l or "failed" in l or "error" in l.lower()]
     result["unit_test_note"] = tail[-1].strip() if tail else "see output"

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -10,7 +10,7 @@ from packaging import version
 from deepctr.feature_column import DenseFeat, SparseFeat
 from deepctr.models import (AFM, BST, CCPM, DCN, DIEN, DIFM, DIN, DSIN, EDCN, FGCNN, FLEN, FNN,
                             FwFM, IFM, MLR, MMOE, NFM, ONN, PLE, PNN, WDL, AutoInt, DCNMix,
-                            DeepFEFM, DeepFM, ESMM, FiBiNET, SharedBottom, xDeepFM, OneTrans, FinalMLP, MaskNet)
+                            DeepFEFM, DeepFM, ESMM, FiBiNET, SharedBottom, xDeepFM, OneTrans, FinalMLP, MaskNet, WuKong)
 
 _TF2 = version.parse(tf.__version__) >= version.parse("2.0.0")
 _TF28 = version.parse(tf.__version__) >= version.parse("2.8.0")
@@ -68,6 +68,7 @@ SINGLE_TASK_MODELS = {
     "EDCN": lambda lin, dnn, task: EDCN(_sparse_only(lin), _sparse_only(dnn), task=task),  # sparse-only,
     'FinalMLP': lambda lin, dnn, task: FinalMLP(lin, dnn, task=task),
     'MaskNet': lambda lin, dnn, task: MaskNet(lin, dnn, task=task),
+    'WuKong': lambda lin, dnn, task: WuKong(lin, dnn, task=task),
 }
 
 # --------------------------------------------------------------------------- #

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -1,0 +1,158 @@
+"""Model registry: maps a model name to a builder that hides each model's
+constructor quirks behind a uniform call. The track runners in ``benchmark.py``
+just look models up here.
+"""
+from __future__ import absolute_import, division, print_function
+
+import tensorflow as tf
+from packaging import version
+
+from deepctr.feature_column import DenseFeat, SparseFeat
+from deepctr.models import (AFM, BST, CCPM, DCN, DIEN, DIFM, DIN, DSIN, EDCN, FGCNN, FLEN, FNN,
+                            FwFM, IFM, MLR, MMOE, NFM, ONN, PLE, PNN, WDL, AutoInt, DCNMix,
+                            DeepFEFM, DeepFM, ESMM, FiBiNET, SharedBottom, xDeepFM)
+
+_TF2 = version.parse(tf.__version__) >= version.parse("2.0.0")
+_TF28 = version.parse(tf.__version__) >= version.parse("2.8.0")
+
+
+class SkipModel(Exception):
+    """Raised by a builder when a model is unsupported in the current env
+    (recorded as status='skipped' rather than 'failed')."""
+
+
+def _sparse_only(feature_columns):
+    """Drop DenseFeat. AFM / CCPM / EDCN declare support_dense=False and only
+    accept sparse (embedding) features."""
+    return [fc for fc in feature_columns if not isinstance(fc, DenseFeat)]
+
+
+def _regroup(feature_columns, n_groups=3):
+    """Round-robin SparseFeat into ``n_groups`` field groups. FLEN's field-wise
+    bi-interaction needs >=2 groups; the generic loader puts everything in one.
+    The grouping is synthetic (no field taxonomy in Criteo)."""
+    out, gi = [], 0
+    for fc in feature_columns:
+        if isinstance(fc, SparseFeat):
+            out.append(fc._replace(group_name="g%d" % (gi % n_groups)))
+            gi += 1
+        else:
+            out.append(fc)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Single-task: builder(linear_fc, dnn_fc, task) -> tf.keras.Model
+# --------------------------------------------------------------------------- #
+SINGLE_TASK_MODELS = {
+    "DeepFM": lambda lin, dnn, task: DeepFM(lin, dnn, task=task),
+    "xDeepFM": lambda lin, dnn, task: xDeepFM(lin, dnn, task=task),
+    "DCN": lambda lin, dnn, task: DCN(lin, dnn, task=task),
+    "DCNMix": lambda lin, dnn, task: DCNMix(lin, dnn, task=task),
+    "AutoInt": lambda lin, dnn, task: AutoInt(lin, dnn, task=task),
+    "FiBiNET": lambda lin, dnn, task: FiBiNET(lin, dnn, task=task),
+    "AFM": lambda lin, dnn, task: AFM(_sparse_only(lin), _sparse_only(dnn), task=task),  # sparse-only
+    "NFM": lambda lin, dnn, task: NFM(lin, dnn, task=task),
+    "PNN": lambda lin, dnn, task: PNN(dnn, task=task),  # DNN-only, no linear part
+    "WDL": lambda lin, dnn, task: WDL(lin, dnn, task=task),
+    "FNN": lambda lin, dnn, task: FNN(lin, dnn, task=task),
+    "FwFM": lambda lin, dnn, task: FwFM(lin, dnn, task=task),
+    "CCPM": lambda lin, dnn, task: CCPM(_sparse_only(lin), _sparse_only(dnn), task=task),  # sparse-only
+    "ONN": lambda lin, dnn, task: ONN(lin, dnn, task=task),
+    "FGCNN": lambda lin, dnn, task: FGCNN(lin, dnn, task=task),
+    "FLEN": lambda lin, dnn, task: FLEN(_regroup(lin), _regroup(dnn), task=task),  # needs >=2 field groups
+    "IFM": lambda lin, dnn, task: IFM(lin, dnn, task=task),
+    "DIFM": lambda lin, dnn, task: DIFM(lin, dnn, task=task),
+    "DeepFEFM": lambda lin, dnn, task: DeepFEFM(lin, dnn, task=task),
+    "MLR": lambda lin, dnn, task: MLR(lin, lin, task=task),  # region == base
+    "EDCN": lambda lin, dnn, task: EDCN(_sparse_only(lin), _sparse_only(dnn), task=task),  # sparse-only
+}
+
+# --------------------------------------------------------------------------- #
+# Multitask: builder(dnn_fc, task_types, task_names) -> tf.keras.Model
+# --------------------------------------------------------------------------- #
+MULTITASK_MODELS = {
+    "SharedBottom": lambda dnn, types, names: SharedBottom(dnn, task_types=types, task_names=names),
+    "ESMM": lambda dnn, types, names: ESMM(dnn, task_types=types, task_names=names),
+    "MMOE": lambda dnn, types, names: MMOE(dnn, task_types=types, task_names=names),
+    "PLE": lambda dnn, types, names: PLE(dnn, task_types=types, task_names=names),
+}
+
+
+# --------------------------------------------------------------------------- #
+# Sequence: each entry says which data view it needs and how to build it.
+# --------------------------------------------------------------------------- #
+def _behavior_embedding_dim(data):
+    target = data.behavior_feature_list[0]
+    for fc in data.feature_columns:
+        if getattr(fc, "name", None) == target:
+            return fc.embedding_dim
+    return 8
+
+
+def _behavior_embedding_sum(data):
+    """Total embedding width of the behavior features (DSIN concatenates them)."""
+    total = 0
+    for fc in data.feature_columns:
+        if getattr(fc, "name", None) in data.behavior_feature_list:
+            total += fc.embedding_dim
+    return total
+
+
+def _largest_divisor_leq(n, cap):
+    for h in range(min(n, cap), 0, -1):
+        if n % h == 0:
+            return h
+    return 1
+
+
+def _build_din(data, task):
+    # Dice activation has serialization/run issues on modern TF; the DIN test
+    # itself switches to 'sigmoid' on TF>=2.8.
+    att_activation = "sigmoid" if _TF28 else "dice"
+    return DIN(data.feature_columns, data.behavior_feature_list,
+               att_activation=att_activation, task=task)
+
+
+def _build_bst(data, task):
+    emb = _behavior_embedding_dim(data)
+    head = _largest_divisor_leq(emb, 8)  # Transformer needs emb_dim % head == 0
+    return BST(data.feature_columns, data.behavior_feature_list, att_head_num=head, task=task)
+
+
+def _build_dien(data, task):
+    if _TF2:
+        raise SkipModel("DIEN's GRU/AUGRU layers depend on legacy TF1 private RNN "
+                        "APIs; unsupported on TensorFlow>=2.0 (its own test skips on TF2).")
+    return DIEN(data.feature_columns, data.behavior_feature_list, gru_type="GRU", task=task)
+
+
+def _build_dsin(data, task):
+    # DSIN requires sum(behavior embedding dims) == att_embedding_size * att_head_num.
+    hist_emb = _behavior_embedding_sum(data)
+    head = _largest_divisor_leq(hist_emb, 8)
+    att_emb = hist_emb // head
+    return DSIN(data.feature_columns, data.behavior_feature_list,
+                sess_max_count=data.sess_max_count,
+                att_embedding_size=att_emb, att_head_num=head, task=task)
+
+
+# view: which SequenceData to feed ('din' for DIN/BST/DIEN, 'dsin' for DSIN)
+SEQUENCE_MODELS = {
+    "DIN": {"view": "din", "build": _build_din},
+    "BST": {"view": "din", "build": _build_bst},
+    "DIEN": {"view": "din", "build": _build_dien},
+    "DSIN": {"view": "dsin", "build": _build_dsin},
+}
+
+
+def select(names, include=None, exclude=None):
+    """Filter an ordered list of model names by --models / --exclude."""
+    out = list(names)
+    if include:
+        inc = set(include)
+        out = [n for n in out if n in inc]
+    if exclude:
+        exc = set(exclude)
+        out = [n for n in out if n not in exc]
+    return out

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -10,7 +10,7 @@ from packaging import version
 from deepctr.feature_column import DenseFeat, SparseFeat
 from deepctr.models import (AFM, BST, CCPM, DCN, DIEN, DIFM, DIN, DSIN, EDCN, FGCNN, FLEN, FNN,
                             FwFM, IFM, MLR, MMOE, NFM, ONN, PLE, PNN, WDL, AutoInt, DCNMix,
-                            DeepFEFM, DeepFM, ESMM, FiBiNET, SharedBottom, xDeepFM)
+                            DeepFEFM, DeepFM, ESMM, FiBiNET, SharedBottom, xDeepFM, OneTrans, FinalMLP, MaskNet)
 
 _TF2 = version.parse(tf.__version__) >= version.parse("2.0.0")
 _TF28 = version.parse(tf.__version__) >= version.parse("2.8.0")
@@ -65,7 +65,9 @@ SINGLE_TASK_MODELS = {
     "DIFM": lambda lin, dnn, task: DIFM(lin, dnn, task=task),
     "DeepFEFM": lambda lin, dnn, task: DeepFEFM(lin, dnn, task=task),
     "MLR": lambda lin, dnn, task: MLR(lin, lin, task=task),  # region == base
-    "EDCN": lambda lin, dnn, task: EDCN(_sparse_only(lin), _sparse_only(dnn), task=task),  # sparse-only
+    "EDCN": lambda lin, dnn, task: EDCN(_sparse_only(lin), _sparse_only(dnn), task=task),  # sparse-only,
+    'FinalMLP': lambda lin, dnn, task: FinalMLP(lin, dnn, task=task),
+    'MaskNet': lambda lin, dnn, task: MaskNet(lin, dnn, task=task),
 }
 
 # --------------------------------------------------------------------------- #
@@ -138,11 +140,21 @@ def _build_dsin(data, task):
 
 
 # view: which SequenceData to feed ('din' for DIN/BST/DIEN, 'dsin' for DSIN)
+def _build_onetrans(data, task):
+    # Transformer-style sequence model: pick head count that divides the
+    # behavior embedding dim (see _build_bst / _build_dsin for the pattern).
+    emb = _behavior_embedding_dim(data)
+    head = _largest_divisor_leq(emb, 4)
+    return OneTrans(data.feature_columns, data.behavior_feature_list,
+                     att_head_num=head, task=task)
+
+
 SEQUENCE_MODELS = {
     "DIN": {"view": "din", "build": _build_din},
     "BST": {"view": "din", "build": _build_bst},
     "DIEN": {"view": "din", "build": _build_dien},
     "DSIN": {"view": "dsin", "build": _build_dsin},
+    'OneTrans': {"view": "din", "build": _build_onetrans},
 }
 
 

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,0 +1,10 @@
+# Extra dependencies for the DeepCTR benchmark suite.
+# These are NOT required by the core deepctr library (which stays lean) and are
+# only needed to run the benchmark pipeline under benchmarks/.
+#
+#   pip install -r benchmarks/requirements.txt
+#
+# TensorFlow is intentionally not listed here: install the build that matches
+# your platform first (see the project README), then deepctr, then these.
+scikit-learn>=0.23
+pandas>=1.0

--- a/deepctr/layers/__init__.py
+++ b/deepctr/layers/__init__.py
@@ -12,6 +12,7 @@ from .onetrans import OneTransLayer, TokenSlice, SinusoidalPositionEncoding
 from .sequence import (AttentionSequencePoolingLayer, BiasEncoding, BiLSTM,
                        KMaxPooling, SequencePoolingLayer, WeightedSequenceLayer,
                        Transformer, DynamicGRU, PositionEncoding)
+from .wukong import WuKongLayer
 from .utils import NoMask, Hash, Linear, _Add, combined_dnn_input, softmax, reduce_sum, Concat
 
 custom_objects = {'tf': tf,
@@ -57,4 +58,5 @@ custom_objects = {'tf': tf,
                   'SinusoidalPositionEncoding': SinusoidalPositionEncoding,
                   'TokenSlice': TokenSlice,
                   'InteractionAggregation': InteractionAggregation,
+                  'WuKongLayer': WuKongLayer,
                   }

--- a/deepctr/layers/__init__.py
+++ b/deepctr/layers/__init__.py
@@ -6,7 +6,9 @@ from .interaction import (CIN, FM, AFMLayer, BiInteractionPooling, CrossNet, Cro
                           InnerProductLayer, InteractingLayer,
                           OutterProductLayer, FGCNNLayer, SENETLayer, BilinearInteraction,
                           FieldWiseBiInteraction, FwFMLayer, FEFMLayer, BridgeModule)
+from .finalmlp import InteractionAggregation
 from .normalization import LayerNormalization
+from .onetrans import OneTransLayer, TokenSlice, SinusoidalPositionEncoding
 from .sequence import (AttentionSequencePoolingLayer, BiasEncoding, BiLSTM,
                        KMaxPooling, SequencePoolingLayer, WeightedSequenceLayer,
                        Transformer, DynamicGRU, PositionEncoding)
@@ -50,5 +52,9 @@ custom_objects = {'tf': tf,
                   'reduce_sum': reduce_sum,
                   'PositionEncoding': PositionEncoding,
                   'RegulationModule': RegulationModule,
-                  'BridgeModule': BridgeModule
+                  'BridgeModule': BridgeModule,
+                  'OneTransLayer': OneTransLayer,
+                  'SinusoidalPositionEncoding': SinusoidalPositionEncoding,
+                  'TokenSlice': TokenSlice,
+                  'InteractionAggregation': InteractionAggregation,
                   }

--- a/deepctr/layers/finalmlp.py
+++ b/deepctr/layers/finalmlp.py
@@ -1,0 +1,74 @@
+# -*- coding:utf-8 -*-
+"""Custom layer for the FinalMLP model: multi-head bilinear interaction
+aggregation that fuses the two MLP streams into the prediction logit.
+
+Reference:
+    Mao K, et al. FinalMLP: An Enhanced Two-Stream MLP Model for CTR Prediction.
+    AAAI 2023. (https://arxiv.org/abs/2304.00902)
+"""
+
+import tensorflow as tf
+from tensorflow.keras.layers import Layer
+
+
+class InteractionAggregation(Layer):
+    """Multi-head bilinear interaction aggregation.
+
+    Given the two stream outputs ``y1`` (B, d1) and ``y2`` (B, d2), produces an
+    ``output_dim`` logit::
+
+        out = b + y1 W1 + y2 W2 + sum_h (y1_h^T W_h y2_h)
+
+    where each stream is split into ``num_heads`` heads for the bilinear term.
+
+    Input shape
+        - list of two 2D tensors ``[(B, d1), (B, d2)]``.
+    Output shape
+        - ``(B, output_dim)``.
+    """
+
+    def __init__(self, num_heads=1, output_dim=1, seed=1024, **kwargs):
+        super(InteractionAggregation, self).__init__(**kwargs)
+        self.num_heads = num_heads
+        self.output_dim = output_dim
+        self.seed = seed
+
+    def build(self, input_shape):
+        if not (isinstance(input_shape, (list, tuple)) and len(input_shape) == 2):
+            raise ValueError("InteractionAggregation expects a list of two inputs")
+        self.d1 = int(input_shape[0][-1])
+        self.d2 = int(input_shape[1][-1])
+        if self.d1 % self.num_heads or self.d2 % self.num_heads:
+            raise ValueError("stream dims (%d, %d) must be divisible by num_heads (%d)"
+                             % (self.d1, self.d2, self.num_heads))
+        self.h1 = self.d1 // self.num_heads
+        self.h2 = self.d2 // self.num_heads
+
+        self.w1 = self.add_weight(name="w1", shape=(self.d1, self.output_dim),
+                                  initializer="glorot_uniform")
+        self.w2 = self.add_weight(name="w2", shape=(self.d2, self.output_dim),
+                                  initializer="glorot_uniform")
+        self.bias = self.add_weight(name="bias", shape=(self.output_dim,),
+                                    initializer="zeros")
+        self.W = self.add_weight(
+            name="W_bilinear",
+            shape=(self.num_heads, self.h1, self.output_dim, self.h2),
+            initializer="glorot_uniform")
+        super(InteractionAggregation, self).build(input_shape)
+
+    def call(self, inputs, **kwargs):
+        y1, y2 = inputs
+        out = self.bias + tf.matmul(y1, self.w1) + tf.matmul(y2, self.w2)  # (B, o)
+        y1_h = tf.reshape(y1, [-1, self.num_heads, self.h1])               # (B, H, h1)
+        y2_h = tf.reshape(y2, [-1, self.num_heads, self.h2])               # (B, H, h2)
+        bilinear = tf.einsum("bhi,hiok,bhk->bo", y1_h, self.W, y2_h)       # (B, o)
+        return out + bilinear
+
+    def compute_output_shape(self, input_shape):
+        return (input_shape[0][0], self.output_dim)
+
+    def get_config(self):
+        config = {"num_heads": self.num_heads, "output_dim": self.output_dim, "seed": self.seed}
+        base = super(InteractionAggregation, self).get_config()
+        base.update(config)
+        return base

--- a/deepctr/layers/onetrans.py
+++ b/deepctr/layers/onetrans.py
@@ -1,0 +1,312 @@
+# -*- coding:utf-8 -*-
+"""
+OneTrans Layer: Unified Feature Interaction and Sequence Modeling.
+
+Assembles feature field tokens and behavior sequence tokens into one token
+sequence, then applies a single Transformer with a mixed attention mask so
+that:
+  - Feature tokens attend bidirectionally to all feature tokens and all
+    valid sequence tokens.
+  - Sequence token at position t attends to all feature tokens and to
+    sequence tokens at positions 0..t (causal), excluding padding.
+
+Reference:
+    OneTrans: Unified Feature Interaction and Sequence Modeling with One
+    Transformer in Industrial Recommender Systems.
+"""
+
+import tensorflow as tf
+
+try:
+    from tensorflow.python.ops.init_ops_v2 import TruncatedNormal, Zeros, glorot_uniform
+except ImportError:
+    from tensorflow.python.ops.init_ops import (
+        TruncatedNormal, Zeros,
+        glorot_uniform_initializer as glorot_uniform,
+    )
+
+from tensorflow.keras.layers import Layer, Dropout
+
+from .normalization import LayerNormalization
+from .utils import reduce_max, softmax
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Positional Encoding (sinusoidal, applied only to sequence tokens)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class SinusoidalPositionEncoding(Layer):
+    """Sinusoidal positional encoding added to sequence tokens."""
+
+    def __init__(self, **kwargs):
+        super(SinusoidalPositionEncoding, self).__init__(**kwargs)
+
+    def call(self, inputs, **kwargs):
+        # inputs: (B, T, D)
+        T = tf.shape(inputs)[1]
+        D = inputs.get_shape().as_list()[-1]
+
+        pos = tf.cast(tf.range(T), tf.float32)           # (T,)
+        dim = tf.cast(tf.range(D), tf.float32)           # (D,)
+        angle = pos[:, tf.newaxis] / tf.pow(
+            10000.0, (2 * (dim[tf.newaxis, :] // 2)) / tf.cast(D, tf.float32)
+        )                                                 # (T, D)
+        sin_enc = tf.math.sin(angle[:, 0::2])
+        cos_enc = tf.math.cos(angle[:, 1::2])
+
+        # Interleave sin/cos
+        pe = tf.reshape(
+            tf.stack([sin_enc, cos_enc], axis=2),
+            [T, -1]
+        )[:, :D]                                          # (T, D)
+
+        return inputs + pe[tf.newaxis, :, :]             # (B, T, D)
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+    def get_config(self):
+        return super(SinusoidalPositionEncoding, self).get_config()
+
+
+class TokenSlice(Layer):
+    """Slice the first ``num_tokens`` positions from a ``(B, N, D)`` sequence.
+
+    A serializable replacement for ``Lambda(lambda t: t[:, :n, :])`` — Lambda
+    layers that wrap a Python ``lambda`` cannot be safely round-tripped through
+    ``save_model``/``load_model``.
+    """
+
+    def __init__(self, num_tokens, **kwargs):
+        super(TokenSlice, self).__init__(**kwargs)
+        self.num_tokens = num_tokens
+
+    def call(self, inputs, **kwargs):
+        return inputs[:, :self.num_tokens, :]
+
+    def compute_output_shape(self, input_shape):
+        return (input_shape[0], self.num_tokens, input_shape[-1])
+
+    def get_config(self):
+        config = {"num_tokens": self.num_tokens}
+        base = super(TokenSlice, self).get_config()
+        base.update(config)
+        return base
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OneTrans single transformer block
+# ─────────────────────────────────────────────────────────────────────────────
+
+class OneTransLayer(Layer):
+    """One Transformer block for OneTrans.
+
+    Processes a combined token sequence of shape ``(B, F+T, D)`` where the
+    first F tokens are feature field tokens and the remaining T tokens are
+    behavior sequence tokens.
+
+    A structured attention mask enforces:
+      - Feature tokens can attend to all feature tokens and all *valid*
+        sequence tokens.
+      - Sequence token at step t can attend to all feature tokens and to
+        sequence tokens at steps 0..t (causal mask), but not to padding.
+
+    Input shape
+        - A list of two tensors:
+          - ``tokens``:     ``(batch_size, F+T, embedding_size)``
+          - ``seq_length``: ``(batch_size, 1)`` — number of valid seq tokens
+
+    Output shape
+        - ``(batch_size, F+T, embedding_size)``
+
+    Arguments
+        - **num_feat_tokens**: int. Number of feature field tokens F.
+        - **seq_len_max**: int. Maximum sequence length T.
+        - **att_embedding_size**: int. Size per attention head.
+        - **head_num**: int. Number of attention heads.
+        - **use_ffn**: bool. Whether to add a point-wise FFN sub-layer.
+        - **ffn_expand**: int. FFN hidden size = embedding_size * ffn_expand.
+        - **dropout_rate**: float.
+        - **use_layer_norm**: bool.
+        - **seed**: int.
+    """
+
+    def __init__(
+        self,
+        num_feat_tokens,
+        seq_len_max,
+        att_embedding_size=8,
+        head_num=4,
+        use_ffn=True,
+        ffn_expand=4,
+        dropout_rate=0.0,
+        use_layer_norm=True,
+        seed=1024,
+        **kwargs,
+    ):
+        super(OneTransLayer, self).__init__(**kwargs)
+        self.F = num_feat_tokens
+        self.T = seq_len_max
+        self.att_embedding_size = att_embedding_size
+        self.head_num = head_num
+        self.num_units = att_embedding_size * head_num
+        self.use_ffn = use_ffn
+        self.ffn_expand = ffn_expand
+        self.dropout_rate = dropout_rate
+        self.use_layer_norm = use_layer_norm
+        self.seed = seed
+
+        # Sub-layers are created in __init__ (not build) so Keras tracks them
+        # consistently for full-model save/load round-trips.
+        self.dropout = Dropout(self.dropout_rate, seed=self.seed)
+        if self.use_layer_norm:
+            self.ln1 = LayerNormalization()
+            self.ln2 = LayerNormalization()
+
+    def build(self, input_shape):
+        embedding_size = int(input_shape[0][-1])
+        if self.num_units != embedding_size:
+            raise ValueError(
+                "att_embedding_size * head_num (%d) must equal embedding_size (%d)"
+                % (self.num_units, embedding_size)
+            )
+
+        self.W_Q = self.add_weight(
+            name="W_Q", shape=[embedding_size, self.num_units],
+            initializer=TruncatedNormal(seed=self.seed))
+        self.W_K = self.add_weight(
+            name="W_K", shape=[embedding_size, self.num_units],
+            initializer=TruncatedNormal(seed=self.seed + 1))
+        self.W_V = self.add_weight(
+            name="W_V", shape=[embedding_size, self.num_units],
+            initializer=TruncatedNormal(seed=self.seed + 2))
+
+        if self.use_ffn:
+            hidden = embedding_size * self.ffn_expand
+            self.fw1 = self.add_weight(
+                name="fw1", shape=[self.num_units, hidden],
+                initializer=glorot_uniform(seed=self.seed))
+            self.fw2 = self.add_weight(
+                name="fw2", shape=[hidden, self.num_units],
+                initializer=glorot_uniform(seed=self.seed + 3))
+
+        super(OneTransLayer, self).build(input_shape)
+
+    # ── attention mask ───────────────────────────────────────────────────────
+
+    def _build_mask(self, seq_length, N):
+        """Build the structured attention mask.
+
+        Returns float mask of shape ``(B, N, N)`` where 1.0 = can attend.
+
+        Layout of the N = F+T token sequence:
+          [feat_0, ..., feat_{F-1}, seq_0, ..., seq_{T-1}]
+        """
+        F, T = self.F, self.T
+
+        # ── valid sequence positions: (B, T) ──
+        # seq_length: (B, 1)
+        seq_valid = tf.sequence_mask(
+            tf.squeeze(seq_length, axis=1), T, dtype=tf.float32
+        )  # (B, T)
+
+        # ── feature-to-feature block: (B, F, F) all 1s ──
+        batch_size = tf.shape(seq_length)[0]
+        ff_block = tf.ones([batch_size, F, F])
+
+        # ── feature-to-seq block: (B, F, T) — valid positions ──
+        # Each feature token attends to all valid seq tokens
+        fs_block = tf.tile(
+            seq_valid[:, tf.newaxis, :], [1, F, 1]
+        )  # (B, F, T)
+
+        # ── seq-to-feature block: (B, T, F) all 1s ──
+        sf_block = tf.ones([batch_size, T, F])
+
+        # ── seq-to-seq block: (B, T, T) causal AND valid ──
+        # Causal mask: lower-triangular (including diagonal)
+        causal = tf.linalg.band_part(tf.ones([T, T]), -1, 0)  # (T, T)
+        # Valid column mask: don't attend to padding positions
+        col_valid = tf.tile(
+            seq_valid[:, tf.newaxis, :], [1, T, 1]
+        )  # (B, T, T)
+        ss_block = causal[tf.newaxis, :, :] * col_valid        # (B, T, T)
+
+        # ── assemble full mask: (B, N, N) ──
+        top    = tf.concat([ff_block, fs_block], axis=2)  # (B, F, N)
+        bottom = tf.concat([sf_block, ss_block], axis=2)  # (B, T, N)
+        mask   = tf.concat([top, bottom], axis=1)         # (B, N, N)
+        return mask
+
+    # ── forward ──────────────────────────────────────────────────────────────
+
+    def call(self, inputs, training=None, **kwargs):
+        tokens, seq_length = inputs
+        # tokens: (B, N, D),  seq_length: (B, 1)
+        N = self.F + self.T
+
+        # ── multi-head self-attention ──
+        Q = tf.tensordot(tokens, self.W_Q, axes=(-1, 0))  # (B, N, D)
+        K = tf.tensordot(tokens, self.W_K, axes=(-1, 0))
+        V = tf.tensordot(tokens, self.W_V, axes=(-1, 0))
+
+        # Split heads: (h*B, N, d)
+        Q_ = tf.concat(tf.split(Q, self.head_num, axis=2), axis=0)
+        K_ = tf.concat(tf.split(K, self.head_num, axis=2), axis=0)
+        V_ = tf.concat(tf.split(V, self.head_num, axis=2), axis=0)
+
+        # Scaled dot-product: (h*B, N, N)
+        scale = self.att_embedding_size ** 0.5
+        scores = tf.matmul(Q_, K_, transpose_b=True) / scale
+
+        # Structured mask: (B, N, N) → tile for heads: (h*B, N, N)
+        mask = self._build_mask(seq_length, N)
+        mask = tf.tile(mask, [self.head_num, 1, 1])
+
+        NEG_INF = -2.0 ** 32 + 1.0
+        paddings = tf.ones_like(scores) * NEG_INF
+        scores = tf.where(tf.equal(mask, 1.0), scores, paddings)
+
+        # Numerical stability + softmax
+        scores -= reduce_max(scores, axis=-1, keep_dims=True)
+        weights = softmax(scores)                           # (h*B, N, N)
+        weights = self.dropout(weights, training=training)
+
+        # Weighted sum: (h*B, N, d) → merge heads → (B, N, D)
+        context = tf.matmul(weights, V_)
+        context = tf.concat(tf.split(context, self.head_num, axis=0), axis=2)
+
+        # Residual + LayerNorm
+        out = tokens + context
+        if self.use_layer_norm:
+            out = self.ln1(out)
+
+        # ── point-wise FFN ──
+        if self.use_ffn:
+            fw = tf.nn.relu(tf.tensordot(out, self.fw1, axes=(-1, 0)))
+            fw = self.dropout(fw, training=training)
+            fw = tf.tensordot(fw, self.fw2, axes=(-1, 0))
+            out = out + fw
+            if self.use_layer_norm:
+                out = self.ln2(out)
+
+        return out
+
+    def compute_output_shape(self, input_shape):
+        return input_shape[0]
+
+    def get_config(self):
+        config = {
+            "num_feat_tokens": self.F,
+            "seq_len_max":     self.T,
+            "att_embedding_size": self.att_embedding_size,
+            "head_num":        self.head_num,
+            "use_ffn":         self.use_ffn,
+            "ffn_expand":      self.ffn_expand,
+            "dropout_rate":    self.dropout_rate,
+            "use_layer_norm":  self.use_layer_norm,
+            "seed":            self.seed,
+        }
+        base = super(OneTransLayer, self).get_config()
+        base.update(config)
+        return base

--- a/deepctr/layers/wukong.py
+++ b/deepctr/layers/wukong.py
@@ -1,0 +1,91 @@
+# -*- coding:utf-8 -*-
+"""Custom layer for the WuKong model: one stackable interaction layer made of a
+Factorization-Machine Block (FMB) and a Linear Compression Block (LCB), joined
+by a residual connection.
+
+Reference:
+    Zhang B, et al. Wukong: Towards a Scaling Law for Large-Scale Recommendation.
+    ICML 2024. (https://arxiv.org/abs/2403.02545)
+"""
+
+import tensorflow as tf
+from tensorflow.keras.layers import Layer, Dropout
+
+from .normalization import LayerNormalization
+
+
+class WuKongLayer(Layer):
+    """One WuKong interaction layer over a token matrix ``X`` of shape (B, k, d).
+
+    * FMB: explicit pairwise interactions ``X X^T`` (B, k, k) → MLP → reshaped to
+      ``(B, n_fmb, d)`` and layer-normed.
+    * LCB: a learned linear recombination of the input embeddings → ``(B, n_lcb, d)``.
+    * Output: ``concat([FMB, LCB], axis=1) + X`` (residual), shape ``(B, k, d)``,
+      so layers stack uniformly.
+
+    Input / output shape: ``(batch_size, k, d)``.
+    """
+
+    def __init__(self, num_fmb_tokens=None, fmb_hidden_dim=128, dropout_rate=0.0,
+                 seed=1024, **kwargs):
+        super(WuKongLayer, self).__init__(**kwargs)
+        self.num_fmb_tokens = num_fmb_tokens
+        self.fmb_hidden_dim = fmb_hidden_dim
+        self.dropout_rate = dropout_rate
+        self.seed = seed
+        self.dropout = Dropout(dropout_rate, seed=seed)
+        self.ln = LayerNormalization()
+
+    def build(self, input_shape):
+        self.k = int(input_shape[1])
+        self.d = int(input_shape[2])
+        # split output tokens so n_fmb + n_lcb == k (keeps the layer stackable)
+        self.n_fmb = self.num_fmb_tokens if self.num_fmb_tokens else max(1, self.k // 2)
+        self.n_fmb = min(self.n_fmb, self.k)
+        self.n_lcb = self.k - self.n_fmb
+
+        # FMB: flatten(X X^T) (k*k) -> hidden -> n_fmb*d
+        self.fmb_w1 = self.add_weight(name="fmb_w1", shape=(self.k * self.k, self.fmb_hidden_dim),
+                                      initializer="glorot_uniform")
+        self.fmb_b1 = self.add_weight(name="fmb_b1", shape=(self.fmb_hidden_dim,),
+                                      initializer="zeros")
+        self.fmb_w2 = self.add_weight(name="fmb_w2", shape=(self.fmb_hidden_dim, self.n_fmb * self.d),
+                                      initializer="glorot_uniform")
+        self.fmb_b2 = self.add_weight(name="fmb_b2", shape=(self.n_fmb * self.d,),
+                                      initializer="zeros")
+        # LCB: (n_lcb, k) linear recombination of input embeddings
+        if self.n_lcb > 0:
+            self.lcb_w = self.add_weight(name="lcb_w", shape=(self.n_lcb, self.k),
+                                         initializer="glorot_uniform")
+        super(WuKongLayer, self).build(input_shape)
+
+    def call(self, inputs, training=None, **kwargs):
+        x = inputs  # (B, k, d)
+        # ── FMB ──
+        inter = tf.matmul(x, x, transpose_b=True)            # (B, k, k)
+        flat = tf.reshape(inter, [-1, self.k * self.k])      # (B, k*k)
+        h = tf.nn.relu(tf.matmul(flat, self.fmb_w1) + self.fmb_b1)
+        h = self.dropout(h, training=training)
+        h = tf.matmul(h, self.fmb_w2) + self.fmb_b2          # (B, n_fmb*d)
+        fmb = tf.reshape(h, [-1, self.n_fmb, self.d])        # (B, n_fmb, d)
+        fmb = self.ln(fmb)
+
+        # ── LCB ──
+        if self.n_lcb > 0:
+            lcb = tf.einsum("lk,bkd->bld", self.lcb_w, x)    # (B, n_lcb, d)
+            out = tf.concat([fmb, lcb], axis=1)              # (B, k, d)
+        else:
+            out = fmb
+
+        # ── residual ──
+        return out + x
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+    def get_config(self):
+        config = {"num_fmb_tokens": self.num_fmb_tokens, "fmb_hidden_dim": self.fmb_hidden_dim,
+                  "dropout_rate": self.dropout_rate, "seed": self.seed}
+        base = super(WuKongLayer, self).get_config()
+        base.update(config)
+        return base

--- a/deepctr/models/__init__.py
+++ b/deepctr/models/__init__.py
@@ -24,6 +24,7 @@ from .edcn import EDCN
 
 from .finalmlp import FinalMLP
 from .masknet import MaskNet
+from .wukong import WuKong
 __all__ = ["AFM", "CCPM", "DCN", "IFM", "DIFM", "DCNMix", "MLR", "DeepFM", "MLR", "NFM", "DIN", "DIEN", "FNN", "PNN",
            "WDL", "xDeepFM", "AutoInt", "ONN", "FGCNN", "DSIN", "FiBiNET", 'FLEN', "FwFM", "BST", "DeepFEFM",
-           "SharedBottom", "ESMM", "MMOE", "PLE", 'EDCN', "OneTrans", "FinalMLP", "MaskNet"]
+           "SharedBottom", "ESMM", "MMOE", "PLE", 'EDCN', "OneTrans", "FinalMLP", "MaskNet", "WuKong"]

--- a/deepctr/models/__init__.py
+++ b/deepctr/models/__init__.py
@@ -17,11 +17,13 @@ from .multitask import SharedBottom, ESMM, MMOE, PLE
 from .nfm import NFM
 from .onn import ONN
 from .pnn import PNN
-from .sequence import DIN, DIEN, DSIN, BST
+from .sequence import DIN, DIEN, DSIN, BST, OneTrans
 from .wdl import WDL
 from .xdeepfm import xDeepFM
 from .edcn import EDCN
 
+from .finalmlp import FinalMLP
+from .masknet import MaskNet
 __all__ = ["AFM", "CCPM", "DCN", "IFM", "DIFM", "DCNMix", "MLR", "DeepFM", "MLR", "NFM", "DIN", "DIEN", "FNN", "PNN",
            "WDL", "xDeepFM", "AutoInt", "ONN", "FGCNN", "DSIN", "FiBiNET", 'FLEN', "FwFM", "BST", "DeepFEFM",
-           "SharedBottom", "ESMM", "MMOE", "PLE", 'EDCN']
+           "SharedBottom", "ESMM", "MMOE", "PLE", 'EDCN', "OneTrans", "FinalMLP", "MaskNet"]

--- a/deepctr/models/finalmlp.py
+++ b/deepctr/models/finalmlp.py
@@ -1,0 +1,67 @@
+# -*- coding:utf-8 -*-
+"""
+FinalMLP
+
+Reference:
+    [1] Mao K, Zhu J, Su L, et al. FinalMLP: An Enhanced Two-Stream MLP Model for
+    CTR Prediction. AAAI 2023. (https://arxiv.org/abs/2304.00902)
+"""
+
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Multiply
+
+from ..feature_column import build_input_features, input_from_feature_columns
+from ..layers.core import PredictionLayer, DNN
+from ..layers.finalmlp import InteractionAggregation
+from ..layers.utils import combined_dnn_input
+
+
+def _feature_selection(emb, gate_units, seed):
+    """Per-stream feature gating: a context MLP produces a sigmoid gate that is
+    multiplied element-wise into the shared embedding, differentiating the two
+    streams' inputs."""
+    feat_dim = int(emb.shape[-1])
+    gate = DNN(gate_units, "relu", seed=seed)(emb) if gate_units else emb
+    gate = Dense(feat_dim, activation="sigmoid")(gate)
+    return Multiply()([emb, gate])
+
+
+def FinalMLP(linear_feature_columns, dnn_feature_columns,
+             mlp1_hidden_units=(128, 64), mlp2_hidden_units=(128, 64),
+             fs1_gate_units=(64,), fs2_gate_units=(64,), num_heads=1,
+             l2_reg_embedding=0.00001, l2_reg_dnn=0, seed=1024, dnn_dropout=0,
+             dnn_activation='relu', dnn_use_bn=False, task='binary'):
+    """Instantiates the FinalMLP architecture (two feature-gated MLP streams fused
+    by a multi-head bilinear interaction aggregation head).
+
+    :param linear_feature_columns: accepted for a uniform builder signature; the
+        input set is built from ``linear + dnn`` columns (FinalMLP itself is
+        MLP-only, with no separate linear/FM logit).
+    :param dnn_feature_columns: features for both MLP streams.
+    :param mlp1_hidden_units / mlp2_hidden_units: layer sizes of the two streams.
+    :param fs1_gate_units / fs2_gate_units: hidden sizes of each stream's feature-selection gate MLP.
+    :param num_heads: number of heads in the interaction aggregation (must divide both stream output dims).
+    :param task: ``"binary"`` or ``"regression"``.
+    :return: A Keras model instance.
+    """
+    features = build_input_features(linear_feature_columns + dnn_feature_columns)
+    inputs_list = list(features.values())
+
+    sparse_embedding_list, dense_value_list = input_from_feature_columns(
+        features, dnn_feature_columns, l2_reg_embedding, seed)
+    emb = combined_dnn_input(sparse_embedding_list, dense_value_list)  # (B, D)
+
+    stream1_in = _feature_selection(emb, fs1_gate_units, seed)
+    stream2_in = _feature_selection(emb, fs2_gate_units, seed + 1)
+
+    stream1 = DNN(mlp1_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout, dnn_use_bn,
+                  seed=seed)(stream1_in)
+    stream2 = DNN(mlp2_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout, dnn_use_bn,
+                  seed=seed + 1)(stream2_in)
+
+    final_logit = InteractionAggregation(num_heads=num_heads, output_dim=1, seed=seed)(
+        [stream1, stream2])
+    output = PredictionLayer(task)(final_logit)
+
+    model = Model(inputs=inputs_list, outputs=output)
+    return model

--- a/deepctr/models/masknet.py
+++ b/deepctr/models/masknet.py
@@ -1,0 +1,77 @@
+# -*- coding:utf-8 -*-
+"""
+MaskNet
+
+Reference:
+    [1] Wang Z, She Q, Zhang J. MaskNet: Introducing Feature-Wise Multiplication to
+    CTR Ranking Models by Instance-Guided Mask. DLP-KDD 2021. (https://arxiv.org/abs/2102.07619)
+"""
+
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Multiply, Activation
+
+from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
+from ..layers.core import PredictionLayer, DNN
+from ..layers.normalization import LayerNormalization
+from ..layers.utils import combined_dnn_input, concat_func, add_func
+
+
+def _mask_block(emb_in, ln_emb, mask_agg_dim, block_dim):
+    """One parallel MaskBlock: an instance-guided multiplicative mask followed by
+    a hidden projection + LayerNorm.
+
+    :param emb_in: raw flattened field embeddings (B, D) — drives the mask.
+    :param ln_emb: layer-normed embeddings (B, D) — the masked signal.
+    """
+    feat_dim = int(ln_emb.shape[-1])
+    # instance-guided mask: aggregation -> projection back to the feature dim
+    mask = Dense(mask_agg_dim, activation="relu")(emb_in)
+    mask = Dense(feat_dim)(mask)
+    masked = Multiply()([ln_emb, mask])
+    hidden = Dense(block_dim, use_bias=False)(masked)
+    hidden = LayerNormalization()(hidden)
+    return Activation("relu")(hidden)
+
+
+def MaskNet(linear_feature_columns, dnn_feature_columns, num_blocks=3, block_dim=64,
+            mask_agg_dim=None, dnn_hidden_units=(128, 64), l2_reg_linear=0.00001,
+            l2_reg_embedding=0.00001, l2_reg_dnn=0, seed=1024, dnn_dropout=0,
+            dnn_activation='relu', dnn_use_bn=False, task='binary'):
+    """Instantiates the parallel MaskNet architecture.
+
+    :param linear_feature_columns: features for the linear part.
+    :param dnn_feature_columns: features for the deep part.
+    :param num_blocks: number of parallel MaskBlocks.
+    :param block_dim: output dim of each MaskBlock's hidden projection.
+    :param mask_agg_dim: aggregation dim of the instance-guided mask MLP
+        (defaults to the embedding feature dim).
+    :param dnn_hidden_units: layer sizes of the DNN on top of the concatenated blocks.
+    :param task: ``"binary"`` or ``"regression"``.
+    :return: A Keras model instance.
+    """
+    features = build_input_features(linear_feature_columns + dnn_feature_columns)
+    inputs_list = list(features.values())
+
+    linear_logit = get_linear_logit(features, linear_feature_columns, seed=seed, prefix='linear',
+                                    l2_reg=l2_reg_linear)
+
+    sparse_embedding_list, dense_value_list = input_from_feature_columns(
+        features, dnn_feature_columns, l2_reg_embedding, seed)
+
+    emb_in = combined_dnn_input(sparse_embedding_list, dense_value_list)  # (B, D)
+    if mask_agg_dim is None:
+        mask_agg_dim = int(emb_in.shape[-1])
+    ln_emb = LayerNormalization()(emb_in)
+
+    blocks = [_mask_block(emb_in, ln_emb, mask_agg_dim, block_dim) for _ in range(num_blocks)]
+    merged = concat_func(blocks) if len(blocks) > 1 else blocks[0]
+
+    dnn_out = DNN(dnn_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout, dnn_use_bn,
+                  seed=seed)(merged)
+    dnn_logit = Dense(1, use_bias=False)(dnn_out)
+
+    final_logit = add_func([linear_logit, dnn_logit])
+    output = PredictionLayer(task)(final_logit)
+
+    model = Model(inputs=inputs_list, outputs=output)
+    return model

--- a/deepctr/models/sequence/__init__.py
+++ b/deepctr/models/sequence/__init__.py
@@ -2,3 +2,4 @@ from .bst import BST
 from .dien import DIEN
 from .din import DIN
 from .dsin import DSIN
+from .onetrans import OneTrans

--- a/deepctr/models/sequence/onetrans.py
+++ b/deepctr/models/sequence/onetrans.py
@@ -1,0 +1,247 @@
+# -*- coding:utf-8 -*-
+"""
+OneTrans: Unified Feature Interaction and Sequence Modeling with One Transformer
+in Industrial Recommender Systems.
+
+Architecture
+------------
+Traditional approaches process feature interaction and sequence modeling in two
+separate modules. OneTrans concatenates all feature field tokens and behavior
+sequence tokens into a single sequence and feeds them into one Transformer:
+
+    [target_item | feat_1 | ... | feat_F | seq_1 | ... | seq_T]
+             ↓  unified Transformer with structured mask  ↓
+    [out_0   | out_1   | ... | out_F   | out_s1 | ... | out_sT]
+             ↓  flatten feature token outputs  ↓
+                          DNN  →  logit
+
+Attention mask:
+  - Feature tokens ↔ feature tokens:   fully bidirectional.
+  - Feature tokens → sequence tokens:  attend to all valid (non-padding) positions.
+  - Sequence token t ← feature tokens: attend to all.
+  - Sequence token t ← sequence t':    causal (t' ≤ t) and non-padding.
+
+Key difference vs BST:
+  BST runs Transformer only over the sequence, then applies target attention to
+  collapse it, and concatenates the result with feature embeddings before DNN.
+  OneTrans feeds features AND sequence tokens together so the Transformer can
+  model cross-interactions between feature fields and sequence items directly.
+
+Reference:
+    OneTrans: Unified Feature Interaction and Sequence Modeling with One
+    Transformer in Industrial Recommender Systems.
+"""
+
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Flatten, Concatenate
+
+from ...feature_column import (
+    SparseFeat, VarLenSparseFeat, DenseFeat, build_input_features,
+)
+from ...inputs import (
+    create_embedding_matrix, embedding_lookup, get_dense_input,
+    varlen_embedding_lookup,
+)
+from ...layers.core import DNN, PredictionLayer
+from ...layers.onetrans import OneTransLayer, SinusoidalPositionEncoding, TokenSlice
+from ...layers.utils import concat_func, combined_dnn_input
+
+
+def OneTrans(
+    dnn_feature_columns,
+    history_feature_list,
+    transformer_num=2,
+    att_head_num=4,
+    att_embedding_size=None,
+    use_ffn=True,
+    ffn_expand=4,
+    dnn_hidden_units=(256, 128, 64),
+    dnn_activation="relu",
+    dnn_dropout=0.0,
+    dnn_use_bn=False,
+    l2_reg_embedding=1e-6,
+    l2_reg_dnn=0,
+    seed=1024,
+    task="binary",
+):
+    """Instantiates the OneTrans model.
+
+    Parameters
+    ----------
+    dnn_feature_columns : list
+        All feature columns used by the model (SparseFeat, VarLenSparseFeat,
+        DenseFeat).  Sequence features must be ``VarLenSparseFeat`` with a
+        ``length_name`` pointing to a ``DenseFeat`` that carries the valid
+        sequence length for each sample.
+    history_feature_list : list of str
+        Names of the **target** sparse features whose sequence counterparts
+        (prefixed with ``"hist_"``) live in ``VarLenSparseFeat`` columns.
+        E.g. ``["item_id"]`` means there is a ``VarLenSparseFeat`` named
+        ``"hist_item_id"`` in ``dnn_feature_columns``.
+    transformer_num : int
+        Number of stacked OneTrans transformer blocks.
+    att_head_num : int
+        Number of attention heads.
+    att_embedding_size : int or None
+        Size per attention head.  If None, inferred as
+        ``embedding_dim // att_head_num`` from the first feature column.
+    use_ffn : bool
+        Whether to include the point-wise FFN sub-layer in each block.
+    ffn_expand : int
+        FFN hidden dim = embedding_dim * ffn_expand.
+    dnn_hidden_units : tuple of int
+        Layer sizes of the final prediction DNN.
+    dnn_activation : str
+        Activation for the DNN.
+    dnn_dropout : float
+        Dropout rate in the DNN and Transformer.
+    dnn_use_bn : bool
+        Whether to use BatchNorm in the DNN.
+    l2_reg_embedding : float
+        L2 regularization on embedding tables.
+    l2_reg_dnn : float
+        L2 regularization on DNN weights.
+    seed : int
+        Random seed.
+    task : str
+        ``"binary"`` or ``"regression"``.
+
+    Returns
+    -------
+    tensorflow.python.keras.Model
+    """
+
+    # ── 1. Build raw input tensors ──────────────────────────────────────────
+    features = build_input_features(dnn_feature_columns)
+    inputs_list = list(features.values())
+
+    # ── 2. Classify feature columns ─────────────────────────────────────────
+    sparse_feature_columns = list(
+        filter(lambda x: isinstance(x, SparseFeat), dnn_feature_columns)
+    ) if dnn_feature_columns else []
+
+    dense_feature_columns = list(
+        filter(lambda x: isinstance(x, DenseFeat), dnn_feature_columns)
+    ) if dnn_feature_columns else []
+
+    varlen_sparse_feature_columns = list(
+        filter(lambda x: isinstance(x, VarLenSparseFeat), dnn_feature_columns)
+    ) if dnn_feature_columns else []
+
+    # Separate history columns from other varlen columns
+    history_fc_names = ["hist_" + name for name in history_feature_list]
+    history_feature_columns = []
+    other_varlen_columns = []
+    for fc in varlen_sparse_feature_columns:
+        if fc.name in history_fc_names:
+            history_feature_columns.append(fc)
+        else:
+            other_varlen_columns.append(fc)
+
+    # ── 3. Retrieve sequence length ─────────────────────────────────────────
+    # Expect a DenseFeat named "seq_length" carrying the valid history length.
+    seq_length = features["seq_length"]          # (B, 1)
+    seq_len_max = history_feature_columns[0].maxlen if history_feature_columns else 1
+
+    # ── 4. Create shared embedding tables ──────────────────────────────────
+    embedding_dict = create_embedding_matrix(
+        dnn_feature_columns, l2_reg_embedding, seed, prefix="", seq_mask_zero=True
+    )
+
+    # ── 5. Collect feature field token embeddings ────────────────────────────
+    # target-item embeddings: sparse features in history_feature_list
+    target_emb_list = embedding_lookup(
+        embedding_dict, features, sparse_feature_columns,
+        return_feat_list=history_feature_list, to_list=True,
+    )
+    # other sparse feature embeddings (context, user attributes, etc.)
+    other_sparse_emb_list = embedding_lookup(
+        embedding_dict, features, sparse_feature_columns,
+        mask_feat_list=history_feature_list, to_list=True,
+    )
+    # pooled other-varlen embeddings (multi-value features, not behavior seq)
+    other_varlen_emb_dict = varlen_embedding_lookup(
+        embedding_dict, features, other_varlen_columns
+    )
+    other_varlen_emb_list = [
+        v for v in other_varlen_emb_dict.values()
+    ]  # each is (B, 1, D) after pooling — we keep the token dim
+
+    # All feature tokens (each is (B, 1, D)):
+    feat_emb_list = target_emb_list + other_sparse_emb_list
+    num_feat_tokens = len(feat_emb_list)
+
+    # ── 6. Collect behavior sequence token embeddings ────────────────────────
+    hist_emb_list = embedding_lookup(
+        embedding_dict, features, history_feature_columns,
+        return_feat_list=history_fc_names, to_list=True,
+    )
+    # hist_emb_list: list of (B, T, D) tensors (one per history feature field)
+    # Sum across fields to keep dimension D consistent with feature tokens.
+    # (Concatenating would give D*n_fields, mismatching feature token dim.)
+    from ...layers.utils import add_func
+    if len(hist_emb_list) == 1:
+        seq_emb = hist_emb_list[0]                           # (B, T, D)
+    else:
+        seq_emb = add_func(hist_emb_list)                    # (B, T, D) element-wise sum
+
+    # ── 7. Add positional encoding to sequence tokens ───────────────────────
+    seq_emb = SinusoidalPositionEncoding()(seq_emb)                    # (B, T, D)
+
+    # ── 8. Determine embedding size & validate heads ────────────────────────
+    embedding_size = int(seq_emb.shape[-1])
+    if att_embedding_size is None:
+        if embedding_size % att_head_num != 0:
+            raise ValueError(
+                "embedding_size (%d) must be divisible by att_head_num (%d). "
+                "Either set att_embedding_size explicitly or adjust att_head_num."
+                % (embedding_size, att_head_num)
+            )
+        att_embedding_size = embedding_size // att_head_num
+
+    # Feature tokens must share the same embedding dimension as seq tokens.
+    # concat_func stacks them along axis=1 → (B, 1, D) each.
+    feat_tokens = concat_func(feat_emb_list, axis=1)         # (B, F, D)
+
+    # ── 9. Build combined token sequence ────────────────────────────────────
+    # Shape: (B, F+T, D)
+    all_tokens = concat_func([feat_tokens, seq_emb], axis=1)
+
+    # ── 10. Stack OneTrans blocks ────────────────────────────────────────────
+    transformer_out = all_tokens
+    for _ in range(transformer_num):
+        transformer_out = OneTransLayer(
+            num_feat_tokens=num_feat_tokens,
+            seq_len_max=seq_len_max,
+            att_embedding_size=att_embedding_size,
+            head_num=att_head_num,
+            use_ffn=use_ffn,
+            ffn_expand=ffn_expand,
+            dropout_rate=dnn_dropout,
+            use_layer_norm=True,
+            seed=seed,
+        )([transformer_out, seq_length])
+        # transformer_out: (B, F+T, D)
+
+    # ── 11. Extract feature token outputs as DNN input ───────────────────────
+    # Take only the first F positions (feature tokens) — they now encode
+    # cross-interaction with the behavior sequence via the unified Transformer.
+    # TokenSlice is a serializable layer (Lambda(lambda ...) cannot round-trip
+    # through save_model/load_model).
+    feat_out = TokenSlice(num_feat_tokens)(transformer_out)  # (B, F, D)
+    feat_out_flat = Flatten()(feat_out)                       # (B, F*D)
+
+    # Dense features (continuous values)
+    dense_value_list = get_dense_input(features, dense_feature_columns)
+
+    # ── 12. DNN + prediction ─────────────────────────────────────────────────
+    dnn_input = combined_dnn_input([feat_out_flat], dense_value_list)
+    dnn_out = DNN(
+        dnn_hidden_units, dnn_activation,
+        l2_reg_dnn, dnn_dropout, dnn_use_bn, seed=seed,
+    )(dnn_input)
+    final_logit = Dense(1, use_bias=False)(dnn_out)
+    output = PredictionLayer(task)(final_logit)
+
+    model = Model(inputs=inputs_list, outputs=output)
+    return model

--- a/deepctr/models/wukong.py
+++ b/deepctr/models/wukong.py
@@ -1,0 +1,66 @@
+# -*- coding:utf-8 -*-
+"""
+WuKong
+
+Reference:
+    [1] Zhang B, Luo L, Chen Y, et al. Wukong: Towards a Scaling Law for
+    Large-Scale Recommendation. ICML 2024. (https://arxiv.org/abs/2403.02545)
+"""
+
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Flatten
+
+from ..feature_column import build_input_features, get_linear_logit, input_from_feature_columns
+from ..layers.core import PredictionLayer, DNN
+from ..layers.utils import concat_func, combined_dnn_input, add_func
+from ..layers.wukong import WuKongLayer
+
+
+def WuKong(linear_feature_columns, dnn_feature_columns, num_layers=3, fmb_hidden_dim=128,
+           num_fmb_tokens=None, dnn_hidden_units=(128, 64), l2_reg_linear=0.00001,
+           l2_reg_embedding=0.00001, l2_reg_dnn=0, seed=1024, dnn_dropout=0,
+           dnn_activation='relu', dnn_use_bn=False, task='binary'):
+    """Instantiates the WuKong architecture.
+
+    Stacks ``num_layers`` WuKong interaction layers (Factorization-Machine Block +
+    Linear Compression Block, with residuals) over the stacked field embeddings,
+    then a DNN head. All sparse / var-len features must share one ``embedding_dim``
+    (the field embeddings are stacked into a (B, num_fields, d) token matrix).
+
+    :param linear_feature_columns: features for the linear part.
+    :param dnn_feature_columns: features for the deep/interaction part.
+    :param num_layers: number of stacked WuKong layers.
+    :param fmb_hidden_dim: hidden size of each FMB's MLP.
+    :param num_fmb_tokens: FMB output tokens per layer (default: half the fields).
+    :param dnn_hidden_units: layer sizes of the DNN head.
+    :param task: ``"binary"`` or ``"regression"``.
+    :return: A Keras model instance.
+    """
+    features = build_input_features(linear_feature_columns + dnn_feature_columns)
+    inputs_list = list(features.values())
+
+    linear_logit = get_linear_logit(features, linear_feature_columns, seed=seed, prefix='linear',
+                                    l2_reg=l2_reg_linear)
+
+    sparse_embedding_list, dense_value_list = input_from_feature_columns(
+        features, dnn_feature_columns, l2_reg_embedding, seed)
+    if not sparse_embedding_list:
+        raise ValueError("WuKong requires at least one embedding (sparse/var-len) feature.")
+
+    # stack field embeddings into a (B, num_fields, d) token matrix
+    x = concat_func(sparse_embedding_list, axis=1)
+    for _ in range(num_layers):
+        x = WuKongLayer(num_fmb_tokens=num_fmb_tokens, fmb_hidden_dim=fmb_hidden_dim,
+                        dropout_rate=dnn_dropout, seed=seed)(x)
+
+    interaction_out = Flatten()(x)
+    dnn_input = combined_dnn_input([interaction_out], dense_value_list)
+    dnn_out = DNN(dnn_hidden_units, dnn_activation, l2_reg_dnn, dnn_dropout, dnn_use_bn,
+                  seed=seed)(dnn_input)
+    dnn_logit = Dense(1, use_bias=False)(dnn_out)
+
+    final_logit = add_func([linear_logit, dnn_logit])
+    output = PredictionLayer(task)(final_logit)
+
+    model = Model(inputs=inputs_list, outputs=output)
+    return model

--- a/docs/source/Features.md
+++ b/docs/source/Features.md
@@ -315,6 +315,18 @@ EDCN introduces two advanced modules, namelybridge moduleandregulation module, w
 [Chen B, Wang Y, Liu Z, et al. Enhancing explicit and implicit feature interactions via information sharing for parallel deep ctr models[C]//Proceedings of the 30th ACM International Conference on Information & Knowledge Management. 2021: 3757-3766.](https://dlp-kdd.github.io/assets/pdf/DLP-KDD_2021_paper_12.pdf)
 
 
+### FinalMLP
+
+Two parallel MLP streams with per-stream feature gating, fused by a multi-head bilinear interaction aggregation head; a simple MLP-only model that rivals complex interaction nets.
+
+[FinalMLP: An Enhanced Two-Stream MLP Model for CTR Prediction](https://arxiv.org/abs/2304.00902)
+
+### MaskNet
+
+Applies instance-guided multiplicative masks on feature embeddings / hidden layers (serial or parallel MaskBlocks) to inject feature-wise multiplicative interactions into an MLP.
+
+[MaskNet: Introducing Feature-Wise Multiplication to CTR Ranking Models by Instance-Guided Mask](https://arxiv.org/abs/2102.07619)
+
 ## Sequence Models
 
 ### DIN (Deep Interest Network)
@@ -374,6 +386,12 @@ BST use the powerful Transformer model to capture the sequential signals underly
 ![BST](../pics/BST.png)
 
 [Qiwei Chen, Huan Zhao, Wei Li, Pipei Huang, and Wenwu Ou. 2019. Behavior sequence transformer for e-commerce recommendation in Alibaba. In Proceedings of the 1st International Workshop on Deep Learning Practice for High-Dimensional Sparse Data (DLP-KDD '19). Association for Computing Machinery, New York, NY, USA, Article 12, 1–4. DOI:)](https://arxiv.org/pdf/1905.06874.pdf)
+
+### OneTrans
+
+Feeds feature-field tokens and behavior-sequence tokens into one Transformer with a structured mask so feature interaction and sequence modeling happen jointly.
+
+[OneTrans: Unified Feature Interaction and Sequence Modeling with One Transformer in Industrial Recommender Systems]()
 
 ## MultiTask Models
 

--- a/docs/source/Features.md
+++ b/docs/source/Features.md
@@ -327,6 +327,12 @@ Applies instance-guided multiplicative masks on feature embeddings / hidden laye
 
 [MaskNet: Introducing Feature-Wise Multiplication to CTR Ranking Models by Instance-Guided Mask](https://arxiv.org/abs/2102.07619)
 
+### WuKong
+
+Stacks factorization-machine blocks (LCB/FMB) with MLPs into a dense architecture whose quality scales predictably with model size (a recommendation scaling law).
+
+[Wukong: Towards a Scaling Law for Large-Scale Recommendation](https://arxiv.org/abs/2403.02545)
+
 ## Sequence Models
 
 ### DIN (Deep Interest Network)

--- a/docs/source/History.md
+++ b/docs/source/History.md
@@ -1,4 +1,5 @@
 # History
+- 06/24/2026 : Add [WuKong](./Features.html#wukong) model via the onboarding pipeline.
 - 06/24/2026 : Add [MaskNet](./Features.html#masknet) model via the onboarding pipeline.
 - 06/24/2026 : Add [FinalMLP](./Features.html#finalmlp) model via the onboarding pipeline.
 - 06/24/2026 : Add [OneTrans](./Features.html#onetrans) model via the onboarding pipeline.

--- a/docs/source/History.md
+++ b/docs/source/History.md
@@ -1,4 +1,7 @@
 # History
+- 06/24/2026 : Add [MaskNet](./Features.html#masknet) model via the onboarding pipeline.
+- 06/24/2026 : Add [FinalMLP](./Features.html#finalmlp) model via the onboarding pipeline.
+- 06/24/2026 : Add [OneTrans](./Features.html#onetrans) model via the onboarding pipeline.
 - 04/16/2026 : [v0.9.4](https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.4) released.Support higher tensorflow version.
 - 11/10/2022 : [v0.9.3](https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.3) released.Add [EDCN](./Features.html#edcn-enhancing-explicit-and-implicit-feature-interactions-dcn).
 - 10/15/2022 : [v0.9.2](https://github.com/shenweichen/DeepCTR/releases/tag/v0.9.2) released.Support python `3.9`,`3.10`.

--- a/docs/source/deepctr.models.finalmlp.rst
+++ b/docs/source/deepctr.models.finalmlp.rst
@@ -1,0 +1,7 @@
+deepctr.models.finalmlp module
+==============================
+
+.. automodule:: deepctr.models.finalmlp
+    :members:
+    :no-undoc-members:
+    :no-show-inheritance:

--- a/docs/source/deepctr.models.masknet.rst
+++ b/docs/source/deepctr.models.masknet.rst
@@ -1,0 +1,7 @@
+deepctr.models.masknet module
+=============================
+
+.. automodule:: deepctr.models.masknet
+    :members:
+    :no-undoc-members:
+    :no-show-inheritance:

--- a/docs/source/deepctr.models.rst
+++ b/docs/source/deepctr.models.rst
@@ -37,6 +37,7 @@ Submodules
    deepctr.models.sequence.onetrans
    deepctr.models.finalmlp
    deepctr.models.masknet
+   deepctr.models.wukong
 
 
 Module contents

--- a/docs/source/deepctr.models.rst
+++ b/docs/source/deepctr.models.rst
@@ -34,6 +34,9 @@ Submodules
    deepctr.models.multitask.esmm
    deepctr.models.multitask.mmoe
    deepctr.models.multitask.ple
+   deepctr.models.sequence.onetrans
+   deepctr.models.finalmlp
+   deepctr.models.masknet
 
 
 Module contents

--- a/docs/source/deepctr.models.sequence.onetrans.rst
+++ b/docs/source/deepctr.models.sequence.onetrans.rst
@@ -1,0 +1,7 @@
+deepctr.models.sequence.onetrans module
+=======================================
+
+.. automodule:: deepctr.models.sequence.onetrans
+    :members:
+    :no-undoc-members:
+    :no-show-inheritance:

--- a/docs/source/deepctr.models.wukong.rst
+++ b/docs/source/deepctr.models.wukong.rst
@@ -1,0 +1,7 @@
+deepctr.models.wukong module
+============================
+
+.. automodule:: deepctr.models.wukong
+    :members:
+    :no-undoc-members:
+    :no-show-inheritance:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,73 @@
+# DeepCTR correctness testing
+
+Passing a training smoke test is necessary, but it does not prove that a paper
+equation was implemented correctly.  DeepCTR uses the following reusable
+correctness ladder.
+
+| Level | Contract | What it catches |
+| --- | --- | --- |
+| C0 | import/build/shape | missing wiring and incompatible signatures |
+| C1 | tiny train + finite inference | broken forward or optimizer paths |
+| C2 | weight and full-model round-trip with equal predictions | incomplete config/custom-object serialization |
+| C3 | independent NumPy reference on deterministic tensors | wrong axes, reductions, head splits, residuals, and equations |
+| C4 | domain invariants and boundary cases | masking, causality, symmetry, padding, empty/minimal inputs |
+| C5 | finite and numerical gradients | disconnected or unstable differentiation paths |
+| C6 | official-code differential / paper-scale reproduction | architectural or preprocessing drift |
+
+## Minimum contracts
+
+- Every model test calls `tests.utils.check_model` (or
+  `tests.utils_mtl.check_mtl_model`) for C0-C2. These helpers compare predictions
+  after both weight-only and complete-model serialization; merely loading
+  without an exception is not sufficient.
+- Correctness fixtures are deterministic. Call `set_test_seed` before generating
+  random inputs so a numerical failure can be reproduced exactly.
+- Every new mathematical custom layer has at least one C3 reference test using
+  `tests.correctness.assert_forward_matches` and one C5 gradient test.
+- Sequence, masking, set, and interaction layers add the relevant C4 invariant.
+- C6 is required before claiming paper reproduction. Benchmark AUC alone is an
+  effectiveness signal, not proof of equation-level correctness.
+
+## Reference-test pattern
+
+```python
+import numpy as np
+
+from tests.correctness import assert_finite_gradients, assert_forward_matches
+
+
+def reference(inputs, weights):
+    # Translate the paper equation independently. Do not call the layer or copy
+    # its TensorFlow expression into NumPy line-for-line.
+    return np.matmul(inputs, weights["kernel"]) + weights["bias"]
+
+
+def test_my_layer_reference_and_gradients():
+    x = np.asarray([[0.2, -0.1]], dtype="float32")
+    layer = MyLayer()
+    deterministic = {
+        "kernel": np.asarray([[0.3], [0.7]], dtype="float32"),
+        "bias": np.asarray([0.1], dtype="float32"),
+    }
+    assert_forward_matches(layer, x, reference, weights=deterministic)
+    assert_finite_gradients(layer, x)
+```
+
+For tiny differentiable tensors, also use `assert_numerical_gradient`.  For
+semantic properties use `assert_invariant`, selecting only the output region
+that should remain unchanged (for example, a causal token before a modified
+future token).
+
+Concrete examples live in `tests/layers/*_correctness_test.py` and cover a
+bilinear equation, a composite interaction block, an exact attention mask, and
+causal invariance.
+
+## Running the contracts
+
+```bash
+CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 \
+  python -m pytest tests/layers/*_correctness_test.py -q
+
+CUDA_VISIBLE_DEVICES="" TF_USE_LEGACY_KERAS=1 \
+  python -m pytest tests/ -q
+```

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -1,0 +1,50 @@
+"""Fast smoke test for the benchmark suite (benchmarks/).
+
+Runs the real track runners on bundled / tiny-synthetic data for one epoch with
+two models each, asserting metrics are produced and leaderboards are written.
+Kept lean so it adds little to CI time.
+"""
+import os
+
+# DeepCTR needs the Keras 2 API; on TF>=2.16 that means legacy Keras. Set it
+# before TensorFlow is imported (mirrors benchmarks/__init__.py and CI).
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
+
+from benchmarks.benchmark import build_parser, run_multitask, run_sequence, run_single
+
+
+def _args(track, tmp_path, **overrides):
+    argv = ["--track", track, "--quick", "--epochs", "1",
+            "--embedding-dim", "4", "--output-dir", str(tmp_path)]
+    args = build_parser().parse_args(argv)
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_single_task_track(tmp_path):
+    results = run_single(_args("single", tmp_path))
+    assert any(r.status == "ok" and "AUC" in r.metrics for r in results)
+    assert (tmp_path / "single_criteo_sample.csv").exists()
+    assert (tmp_path / "single_criteo_sample.md").exists()
+
+
+def test_multitask_track(tmp_path):
+    results = run_multitask(_args("multitask", tmp_path))
+    assert any(r.status == "ok" and "mean_AUC" in r.metrics for r in results)
+    assert (tmp_path / "multitask_census.csv").exists()
+
+
+def test_sequence_track(tmp_path):
+    results = run_sequence(_args("sequence", tmp_path))
+    by_model = {r.model: r for r in results}
+    # DIN must train and produce an AUC; DIEN is cleanly skipped on TF>=2.0.
+    assert by_model["DIN"].status == "ok" and "AUC" in by_model["DIN"].metrics
+    assert (tmp_path / "sequence_synthetic_seq.csv").exists()
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -43,6 +43,58 @@ def test_sequence_track(tmp_path):
     assert (tmp_path / "sequence_synthetic_seq.csv").exists()
 
 
+def test_temporal_split_holds_out_most_recent_rows(tmp_path):
+    """--temporal-split must hold out the most recent rows (by --time-col),
+    never random ones, so no future information leaks into training."""
+    import numpy as np
+    import pandas as pd
+
+    from benchmarks.datasets.criteo import COLUMNS, load_criteo
+
+    n = 100
+    df = pd.DataFrame({c: [0] * n for c in COLUMNS})
+    df["ts"] = list(range(n))           # ascending time
+    df["label"] = [0] * 80 + [1] * 20   # the 20 most-recent rows are the positives
+    # Shuffle file order so a correct split must rely on `ts`, not row position.
+    df = df.iloc[np.random.RandomState(0).permutation(n)].reset_index(drop=True)
+    path = tmp_path / "criteo_ts.csv"
+    df.to_csv(path, index=False)
+
+    data = load_criteo(data_path=str(path), temporal_split=True, time_col="ts", test_size=0.2)
+
+    assert len(data.train_y) == 80 and len(data.test_y) == 20
+    # Most-recent 20% (ts 80..99 -> all positives) must be exactly the test set.
+    assert set(data.test_y.flatten().tolist()) == {1}
+    assert set(data.train_y.flatten().tolist()) == {0}
+
+
+def _census_row(income, marital):
+    from benchmarks.datasets.census import COLUMN_NAMES
+
+    vals = ["0"] * len(COLUMN_NAMES)
+    vals[COLUMN_NAMES.index("marital_stat")] = marital
+    vals[COLUMN_NAMES.index("income_50k")] = income
+    return ",".join(vals)
+
+
+def test_census_uses_official_test_partition(tmp_path):
+    """When a sibling .test file exists, load_census must use that official
+    partition rather than reshuffling a random split out of .data."""
+    from benchmarks.datasets.census import load_census
+
+    train_rows = [_census_row(" 50000+.", " Never married")] * 10 + \
+                 [_census_row(" - 50000.", " Married")] * 10          # 20 train rows
+    test_rows = [_census_row(" - 50000.", " Married")] * 7            # 7 test rows
+    (tmp_path / "mini.data").write_text("\n".join(train_rows) + "\n")
+    (tmp_path / "mini.test").write_text("\n".join(test_rows) + "\n")
+
+    data = load_census(data_path=str(tmp_path / "mini.data"))
+
+    # Official split -> exactly the .test rows (a random 0.2 split would give 5).
+    assert len(data.train_y[0]) == 20
+    assert len(data.test_y[0]) == 7
+
+
 if __name__ == "__main__":
     import sys
     import pytest

--- a/tests/correctness.py
+++ b/tests/correctness.py
@@ -1,0 +1,253 @@
+"""Reusable correctness contracts for DeepCTR layers and models.
+
+These helpers deliberately test semantics rather than merely checking that a
+graph can be built.  A strong test normally combines:
+
+* an independent NumPy reference for the paper equation;
+* finite (and, for small tensors, numerical) gradients;
+* an invariant such as padding, causality, or permutation behaviour; and
+* prediction equivalence after serialization.
+
+The module lives under ``tests`` so the core package keeps no pytest/runtime
+dependency on the test framework.
+"""
+from __future__ import absolute_import, division, print_function
+
+import copy
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import tensorflow as tf
+from numpy.testing import assert_allclose
+from tensorflow.keras import backend as K
+from tensorflow.keras.models import load_model, save_model
+
+
+def set_test_seed(seed=2020):
+    """Seed NumPy and TensorFlow for reproducible correctness fixtures."""
+    np.random.seed(seed)
+    if hasattr(tf.random, "set_seed"):
+        tf.random.set_seed(seed)
+    else:  # TensorFlow 1.x compatibility
+        tf.set_random_seed(seed)
+
+
+def _invoke(subject, inputs, training=False):
+    """Call a Keras layer/model or a plain callable consistently."""
+    if hasattr(subject, "call"):
+        return subject(inputs, training=training)
+    return subject(inputs)
+
+
+def _to_tensor(value):
+    if tf.is_tensor(value):
+        return value
+    return tf.convert_to_tensor(value)
+
+
+def _to_numpy(value):
+    if isinstance(value, np.ndarray):
+        return value
+    if hasattr(value, "numpy"):
+        return value.numpy()
+    return K.get_value(value)
+
+
+def _numpy_tree(values):
+    return tf.nest.map_structure(_to_numpy, values)
+
+
+def assert_nested_allclose(actual, expected, rtol=1e-5, atol=1e-6):
+    """Assert equality for tensor/array outputs, including nested outputs."""
+    actual_flat = tf.nest.flatten(_numpy_tree(actual))
+    expected_flat = tf.nest.flatten(_numpy_tree(expected))
+    if len(actual_flat) != len(expected_flat):
+        raise AssertionError("output structures differ: %d != %d" %
+                             (len(actual_flat), len(expected_flat)))
+    for index, (actual_value, expected_value) in enumerate(zip(actual_flat, expected_flat)):
+        if not np.all(np.isfinite(actual_value)):
+            raise AssertionError("output %d contains NaN or infinity" % index)
+        assert_allclose(actual_value, expected_value, rtol=rtol, atol=atol,
+                        err_msg="output %d differs from reference" % index)
+
+
+def named_weights(subject):
+    """Return layer weights by full variable name and, when unique, leaf name.
+
+    Reference functions can normally use stable leaf names such as ``w1`` or
+    ``W_Q`` without depending on Keras-generated layer scopes.  Ambiguous leaf
+    names are intentionally omitted; their full names remain available.
+    """
+    result = {}
+    leaf_counts = {}
+    values = []
+    for variable in subject.weights:
+        full_name = variable.name.split(":", 1)[0]
+        leaf_name = full_name.rsplit("/", 1)[-1]
+        value = _to_numpy(variable)
+        result[full_name] = value
+        values.append((leaf_name, value))
+        leaf_counts[leaf_name] = leaf_counts.get(leaf_name, 0) + 1
+    for leaf_name, value in values:
+        if leaf_counts[leaf_name] == 1:
+            result[leaf_name] = value
+    return result
+
+
+def assign_named_weights(subject, values):
+    """Assign a dict of deterministic arrays to weights by full or leaf name."""
+    variables = {}
+    leaf_counts = {}
+    leaves = []
+    for variable in subject.weights:
+        full_name = variable.name.split(":", 1)[0]
+        leaf_name = full_name.rsplit("/", 1)[-1]
+        variables[full_name] = variable
+        leaves.append((leaf_name, variable))
+        leaf_counts[leaf_name] = leaf_counts.get(leaf_name, 0) + 1
+    for leaf_name, variable in leaves:
+        if leaf_counts[leaf_name] == 1:
+            variables[leaf_name] = variable
+
+    unknown = sorted(set(values) - set(variables))
+    if unknown:
+        raise KeyError("unknown weight names: %s" % ", ".join(unknown))
+    for name, value in values.items():
+        variable = variables[name]
+        value = np.asarray(value, dtype=K.get_value(variable).dtype)
+        expected_shape = tuple(int(dim) for dim in variable.shape)
+        if value.shape != expected_shape:
+            raise ValueError("weight %s has shape %s; expected %s" %
+                             (name, value.shape, expected_shape))
+        K.set_value(variable, value)
+
+
+def assert_forward_matches(subject, inputs, reference_fn, weights=None,
+                           rtol=1e-5, atol=1e-6):
+    """Compare a layer/model forward pass with an independent reference.
+
+    ``reference_fn`` receives ``(numpy_inputs, named_weight_dict)``.  It must not
+    call ``subject`` or reuse the implementation under test.  ``weights`` may be
+    either a Keras-ordered list or a dict accepted by
+    :func:`assign_named_weights`.
+    """
+    tensor_inputs = tf.nest.map_structure(_to_tensor, inputs)
+    _invoke(subject, tensor_inputs, training=False)  # build variables
+    if weights is not None:
+        if isinstance(weights, dict):
+            assign_named_weights(subject, weights)
+        else:
+            subject.set_weights(weights)
+    actual = _invoke(subject, tensor_inputs, training=False)
+    expected = reference_fn(_numpy_tree(tensor_inputs), named_weights(subject))
+    assert_nested_allclose(actual, expected, rtol=rtol, atol=atol)
+    return _numpy_tree(actual)
+
+
+def assert_finite_gradients(subject, inputs, loss_fn=None, require_all=True):
+    """Assert that differentiable inputs and trainable weights have gradients."""
+    if not hasattr(tf, "GradientTape") or not tf.executing_eagerly():
+        raise RuntimeError("gradient contracts require TensorFlow eager execution")
+
+    watched = []
+
+    def make_input(value):
+        array = np.asarray(value)
+        if np.issubdtype(array.dtype, np.floating):
+            variable = tf.Variable(array)
+            watched.append(variable)
+            return variable
+        return tf.convert_to_tensor(array)
+
+    tensor_inputs = tf.nest.map_structure(make_input, inputs)
+    with tf.GradientTape() as tape:
+        outputs = _invoke(subject, tensor_inputs, training=False)
+        if loss_fn is None:
+            terms = [tf.reduce_sum(tf.cast(value, tf.float32))
+                     for value in tf.nest.flatten(outputs)]
+            loss = tf.add_n(terms)
+        else:
+            loss = loss_fn(outputs)
+
+    targets = watched + list(subject.trainable_weights)
+    gradients = tape.gradient(loss, targets)
+    for target, gradient in zip(targets, gradients):
+        if gradient is None:
+            if require_all:
+                raise AssertionError("missing gradient for %s" % getattr(target, "name", "input"))
+            continue
+        gradient_value = _to_numpy(gradient)
+        if not np.all(np.isfinite(gradient_value)):
+            raise AssertionError("non-finite gradient for %s" % getattr(target, "name", "input"))
+    return gradients
+
+
+def assert_numerical_gradient(subject, inputs, rtol=2e-2, atol=2e-3, delta=1e-3):
+    """Compare analytic and finite-difference input Jacobians on tiny tensors.
+
+    This intentionally targets inputs rather than weights; weight gradients are
+    covered cheaply by :func:`assert_finite_gradients`.  Keep tensors small,
+    because a full Jacobian is materialized.
+    """
+    if not hasattr(tf.test, "compute_gradient") or not tf.executing_eagerly():
+        raise RuntimeError("numerical gradients require TensorFlow eager execution")
+    if isinstance(inputs, dict):
+        raise TypeError("numerical gradient helper supports a tensor or list/tuple, not dict")
+
+    is_sequence = isinstance(inputs, (list, tuple))
+    input_values = list(inputs) if is_sequence else [inputs]
+    tensors = [tf.convert_to_tensor(value) for value in input_values]
+    if any(not tensor.dtype.is_floating for tensor in tensors):
+        raise TypeError("all numerical-gradient inputs must be floating point")
+
+    def function(*args):
+        structured = type(inputs)(args) if is_sequence else args[0]
+        output = _invoke(subject, structured, training=False)
+        if len(tf.nest.flatten(output)) != 1:
+            raise TypeError("numerical gradient helper requires one output tensor")
+        return tf.nest.flatten(output)[0]
+
+    theoretical, numerical = tf.test.compute_gradient(function, tensors, delta=delta)
+    for index, (analytic, finite_difference) in enumerate(zip(theoretical, numerical)):
+        assert_allclose(analytic, finite_difference, rtol=rtol, atol=atol,
+                        err_msg="input %d analytic gradient differs from finite difference" % index)
+
+
+def assert_invariant(subject, inputs, transform, output_selector=None,
+                     rtol=1e-5, atol=1e-6):
+    """Assert an output is unchanged by a semantics-preserving input transform."""
+    selector = output_selector or (lambda value: value)
+    baseline_inputs = copy.deepcopy(inputs)
+    changed_inputs = transform(copy.deepcopy(inputs))
+    baseline = selector(_invoke(subject, tf.nest.map_structure(_to_tensor, baseline_inputs),
+                                training=False))
+    changed = selector(_invoke(subject, tf.nest.map_structure(_to_tensor, changed_inputs),
+                               training=False))
+    assert_nested_allclose(changed, baseline, rtol=rtol, atol=atol)
+
+
+def predict_numpy(model, inputs):
+    """Predict without progress output and normalize nested results to NumPy."""
+    try:
+        predictions = model.predict(inputs, verbose=0)
+    except TypeError:  # old Keras versions without the verbose keyword
+        predictions = model.predict(inputs)
+    return _numpy_tree(predictions)
+
+
+def assert_serialization_predictions(model, inputs, custom_objects,
+                                     rtol=1e-5, atol=1e-6):
+    """Save/load a complete model and compare every prediction tensor."""
+    before = predict_numpy(model, inputs)
+    temp_dir = tempfile.mkdtemp(prefix="deepctr-model-")
+    model_path = os.path.join(temp_dir, "model.h5")
+    try:
+        save_model(model, model_path)
+        restored = load_model(model_path, custom_objects)
+        after = predict_numpy(restored, inputs)
+        assert_nested_allclose(after, before, rtol=rtol, atol=atol)
+        return restored
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/layers/FinalMLP_correctness_test.py
+++ b/tests/layers/FinalMLP_correctness_test.py
@@ -1,0 +1,36 @@
+"""Equation and gradient contracts for FinalMLP's reusable core layer."""
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+from deepctr.layers.finalmlp import InteractionAggregation
+from tests.correctness import (assert_finite_gradients, assert_forward_matches,
+                               assert_numerical_gradient)
+
+
+def _reference(inputs, weights):
+    y1, y2 = inputs
+    linear = weights["bias"] + np.matmul(y1, weights["w1"]) + np.matmul(y2, weights["w2"])
+    heads = weights["W_bilinear"].shape[0]
+    y1_heads = y1.reshape((-1, heads, y1.shape[-1] // heads))
+    y2_heads = y2.reshape((-1, heads, y2.shape[-1] // heads))
+    bilinear = np.einsum("bhi,hiok,bhk->bo", y1_heads, weights["W_bilinear"], y2_heads)
+    return linear + bilinear
+
+
+def test_reference_and_gradients_for_bilinear_interaction():
+    y1 = np.asarray([[0.2, -0.3, 0.5, 0.7],
+                     [0.1, 0.4, -0.2, 0.8]], dtype="float32")
+    y2 = np.asarray([[0.6, -0.1, 0.9, 0.3],
+                     [-0.5, 0.2, 0.4, 0.7]], dtype="float32")
+    layer = InteractionAggregation(num_heads=2, output_dim=2)
+    weights = {
+        "w1": np.arange(8, dtype="float32").reshape(4, 2) / 10.0,
+        "w2": np.arange(8, 16, dtype="float32").reshape(4, 2) / 20.0,
+        "bias": np.asarray([0.1, -0.2], dtype="float32"),
+        "W_bilinear": np.arange(16, dtype="float32").reshape(2, 2, 2, 2) / 25.0,
+    }
+
+    assert_forward_matches(layer, [y1, y2], _reference, weights=weights)
+    assert_finite_gradients(layer, [y1, y2])
+    assert_numerical_gradient(layer, [y1[:1], y2[:1]], rtol=3e-2, atol=3e-3)

--- a/tests/layers/OneTrans_correctness_test.py
+++ b/tests/layers/OneTrans_correctness_test.py
@@ -1,0 +1,55 @@
+"""Exact mask and causal-invariance contracts for OneTrans."""
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import tensorflow as tf
+from numpy.testing import assert_allclose
+
+from deepctr.layers.onetrans import OneTransLayer
+from tests.correctness import assert_invariant, assign_named_weights
+
+
+def _expected_mask():
+    return np.asarray([
+        # seq_length = 2; layout is [feature_0, feature_1, seq_0, seq_1, seq_2]
+        [[1, 1, 1, 1, 0],
+         [1, 1, 1, 1, 0],
+         [1, 1, 1, 0, 0],
+         [1, 1, 1, 1, 0],
+         [1, 1, 1, 1, 0]],
+        # seq_length = 1
+        [[1, 1, 1, 0, 0],
+         [1, 1, 1, 0, 0],
+         [1, 1, 1, 0, 0],
+         [1, 1, 1, 0, 0],
+         [1, 1, 1, 0, 0]],
+    ], dtype="float32")
+
+
+def test_attention_mask_matches_structured_contract():
+    layer = OneTransLayer(num_feat_tokens=2, seq_len_max=3,
+                          att_embedding_size=2, head_num=1,
+                          use_ffn=False, use_layer_norm=False)
+    lengths = tf.constant([[2], [1]], dtype=tf.int32)
+    actual = layer._build_mask(lengths, 5)
+    assert_allclose(actual.numpy(), _expected_mask(), rtol=0, atol=0)
+
+
+def test_causal_output_is_invariant_to_future_token_changes():
+    tokens = np.asarray([[[0.1, 0.2], [0.3, -0.1],
+                          [0.5, 0.4], [0.7, -0.2], [0.9, 0.6]]], dtype="float32")
+    lengths = np.asarray([[3]], dtype="int32")
+    layer = OneTransLayer(num_feat_tokens=2, seq_len_max=3,
+                          att_embedding_size=2, head_num=1,
+                          use_ffn=False, use_layer_norm=False, dropout_rate=0.0)
+    layer([tf.constant(tokens), tf.constant(lengths)], training=False)
+    identity = np.eye(2, dtype="float32")
+    assign_named_weights(layer, {"W_Q": identity, "W_K": identity, "W_V": identity})
+
+    def change_future(values):
+        values[0][0, 4, :] = np.asarray([100.0, -100.0], dtype="float32")
+        return values
+
+    # seq_0 is token index 2. Its causal receptive field excludes seq_2.
+    assert_invariant(layer, [tokens, lengths], change_future,
+                     output_selector=lambda output: output[:, 2, :])

--- a/tests/layers/WuKong_correctness_test.py
+++ b/tests/layers/WuKong_correctness_test.py
@@ -1,0 +1,43 @@
+"""Equation and gradient contracts for WuKong's composite interaction block."""
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+from deepctr.layers.wukong import WuKongLayer
+from tests.correctness import assert_finite_gradients, assert_forward_matches
+
+
+def _reference(inputs, weights):
+    x = inputs
+    batch_size, _token_count, embedding_dim = x.shape
+    interaction = np.matmul(x, np.swapaxes(x, 1, 2)).reshape(batch_size, -1)
+    hidden = np.maximum(np.matmul(interaction, weights["fmb_w1"]) + weights["fmb_b1"], 0.0)
+    fmb = np.matmul(hidden, weights["fmb_w2"]) + weights["fmb_b2"]
+    fmb = fmb.reshape(batch_size, 1, embedding_dim)
+
+    mean = np.mean(fmb, axis=-1, keepdims=True)
+    variance = np.mean(np.square(fmb - mean), axis=-1, keepdims=True)
+    fmb = (fmb - mean) / np.sqrt(variance + 1e-9)
+    fmb = fmb * weights["gamma"] + weights["beta"]
+
+    lcb = np.einsum("lk,bkd->bld", weights["lcb_w"], x)
+    return np.concatenate([fmb, lcb], axis=1) + x
+
+
+def test_reference_and_gradients_for_composite_interaction_block():
+    x = np.asarray([[[0.2, 0.7], [0.5, -0.3], [0.8, 0.1]],
+                    [[-0.4, 0.6], [0.9, 0.2], [0.3, -0.5]]], dtype="float32")
+    layer = WuKongLayer(num_fmb_tokens=1, fmb_hidden_dim=2, dropout_rate=0.0)
+    weights = {
+        "fmb_w1": np.arange(18, dtype="float32").reshape(9, 2) / 30.0 - 0.2,
+        "fmb_b1": np.asarray([0.2, 0.1], dtype="float32"),
+        "fmb_w2": np.asarray([[0.4, -0.2], [0.1, 0.5]], dtype="float32"),
+        "fmb_b2": np.asarray([0.05, -0.1], dtype="float32"),
+        "lcb_w": np.asarray([[0.3, -0.2, 0.5], [-0.4, 0.6, 0.2]], dtype="float32"),
+        "gamma": np.asarray([1.2, 0.8], dtype="float32"),
+        "beta": np.asarray([0.1, -0.1], dtype="float32"),
+    }
+
+    assert_forward_matches(layer, x, _reference, weights=weights,
+                           rtol=2e-5, atol=2e-5)
+    assert_finite_gradients(layer, x)

--- a/tests/models/EDCN_test.py
+++ b/tests/models/EDCN_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from deepctr.models import EDCN
+from tests.correctness import set_test_seed
 from ..utils import check_model, get_test_data, SAMPLE_SIZE
 
 
@@ -15,6 +16,7 @@ from ..utils import check_model, get_test_data, SAMPLE_SIZE
 )
 def test_EDCN(bridge_type, cross_num, cross_parameterization, sparse_feature_num):
     model_name = "EDCN"
+    set_test_seed(0)
 
     sample_size = SAMPLE_SIZE
     x, y, feature_columns = get_test_data(sample_size, sparse_feature_num=sparse_feature_num,

--- a/tests/models/FinalMLP_test.py
+++ b/tests/models/FinalMLP_test.py
@@ -1,0 +1,26 @@
+import pytest
+
+from deepctr.models import FinalMLP
+from ..utils import check_model, get_test_data, SAMPLE_SIZE
+
+
+@pytest.mark.parametrize(
+    'mlp_units,num_heads,sparse_feature_num',
+    [((4,), 1, 1),
+     ((4, 2), 2, 2)]
+)
+def test_FinalMLP(mlp_units, num_heads, sparse_feature_num):
+    model_name = "FinalMLP"
+    sample_size = SAMPLE_SIZE
+    x, y, feature_columns = get_test_data(sample_size, sparse_feature_num=sparse_feature_num,
+                                          dense_feature_num=sparse_feature_num)
+
+    model = FinalMLP(feature_columns, feature_columns,
+                     mlp1_hidden_units=mlp_units, mlp2_hidden_units=mlp_units,
+                     fs1_gate_units=(4,), fs2_gate_units=(4,), num_heads=num_heads, dnn_dropout=0.5)
+
+    check_model(model, model_name, x, y)
+
+
+if __name__ == "__main__":
+    pass

--- a/tests/models/MaskNet_test.py
+++ b/tests/models/MaskNet_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from deepctr.models import MaskNet
+from ..utils import check_model, get_test_data, SAMPLE_SIZE
+
+
+@pytest.mark.parametrize(
+    'hidden_size,sparse_feature_num',
+    [((2,), 1),
+     ((3,), 2)]
+)
+def test_MaskNet(hidden_size, sparse_feature_num):
+    model_name = "MaskNet"
+    sample_size = SAMPLE_SIZE
+    x, y, feature_columns = get_test_data(sample_size, sparse_feature_num=sparse_feature_num,
+                                          dense_feature_num=sparse_feature_num)
+
+    model = MaskNet(feature_columns, feature_columns, dnn_hidden_units=hidden_size, dnn_dropout=0.5)
+
+    check_model(model, model_name, x, y)
+
+
+if __name__ == "__main__":
+    pass

--- a/tests/models/OneTrans_test.py
+++ b/tests/models/OneTrans_test.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+from deepctr.feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, get_feature_names
+from deepctr.models import OneTrans
+from ..utils import check_model
+
+# NOTE: this model concatenates feature tokens with sequence tokens, so every
+# sparse / history feature must share the SAME embedding_dim.
+EMB = 8
+
+
+def get_xy_fd():
+    feature_columns = [
+        SparseFeat('user', 3, embedding_dim=EMB),
+        SparseFeat('gender', 2, embedding_dim=EMB),
+        SparseFeat('item_id', 3 + 1, embedding_dim=EMB),
+        SparseFeat('cate_id', 2 + 1, embedding_dim=EMB),
+        DenseFeat('pay_score', 1),
+    ]
+    feature_columns += [
+        VarLenSparseFeat(SparseFeat('hist_item_id', vocabulary_size=3 + 1, embedding_dim=EMB,
+                                    embedding_name='item_id'), maxlen=4, length_name="seq_length"),
+        VarLenSparseFeat(SparseFeat('hist_cate_id', vocabulary_size=2 + 1, embedding_dim=EMB,
+                                    embedding_name='cate_id'), maxlen=4, length_name="seq_length"),
+    ]
+    # History behavior sequence feature name must start with "hist_".
+    behavior_feature_list = ["item_id", "cate_id"]
+
+    uid = np.array([0, 1, 2])
+    ugender = np.array([0, 1, 0])
+    iid = np.array([1, 2, 3])       # 0 is the mask value
+    cate_id = np.array([1, 2, 2])   # 0 is the mask value
+    pay_score = np.array([0.1, 0.2, 0.3])
+
+    hist_iid = np.array([[1, 2, 3, 0], [3, 2, 1, 0], [1, 2, 0, 0]])
+    hist_cate_id = np.array([[1, 2, 2, 0], [2, 2, 1, 0], [1, 2, 0, 0]])
+    seq_length = np.array([3, 3, 2])  # actual length of each behavior sequence
+
+    feature_dict = {'user': uid, 'gender': ugender, 'item_id': iid, 'cate_id': cate_id,
+                    'hist_item_id': hist_iid, 'hist_cate_id': hist_cate_id,
+                    'pay_score': pay_score, 'seq_length': seq_length}
+    x = {name: feature_dict[name] for name in get_feature_names(feature_columns)}
+    y = np.array([1, 0, 1])
+    return x, y, feature_columns, behavior_feature_list
+
+
+def test_OneTrans():
+    model_name = "OneTrans"
+    x, y, feature_columns, behavior_feature_list = get_xy_fd()
+    model = OneTrans(feature_columns, behavior_feature_list,
+                 dnn_hidden_units=[4, 4], att_head_num=2)
+    check_model(model, model_name, x, y)
+
+
+if __name__ == "__main__":
+    pass

--- a/tests/models/WuKong_test.py
+++ b/tests/models/WuKong_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from deepctr.models import WuKong
+from ..utils import check_model, get_test_data, SAMPLE_SIZE
+
+
+@pytest.mark.parametrize(
+    'hidden_size,sparse_feature_num',
+    [((2,), 1),
+     ((3,), 2)]
+)
+def test_WuKong(hidden_size, sparse_feature_num):
+    model_name = "WuKong"
+    sample_size = SAMPLE_SIZE
+    x, y, feature_columns = get_test_data(sample_size, sparse_feature_num=sparse_feature_num,
+                                          dense_feature_num=sparse_feature_num)
+
+    model = WuKong(feature_columns, feature_columns, dnn_hidden_units=hidden_size, dnn_dropout=0.5)
+
+    check_model(model, model_name, x, y)
+
+
+if __name__ == "__main__":
+    pass

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,10 +10,12 @@ from numpy.testing import assert_allclose
 from packaging import version
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Input, Masking
-from tensorflow.keras.models import Model, load_model, save_model
+from tensorflow.keras.models import Model
 
 from deepctr.feature_column import SparseFeat, VarLenSparseFeat, DenseFeat, DEFAULT_GROUP_NAME
 from deepctr.layers import custom_objects
+from tests.correctness import (assert_nested_allclose, assert_serialization_predictions,
+                               predict_numpy)
 
 SAMPLE_SIZE = 8
 VOCABULARY_SIZE = 4
@@ -355,7 +357,14 @@ def has_arg(fn, name, accept_all=False):
 
 def check_model(model, model_name, x, y, check_model_io=True):
     """
-    compile model,train and evaluate it,then save/load weight and model file.
+    Compile/train a model, then enforce the generic model correctness contract:
+
+    * inference is finite;
+    * predictions survive a weight round-trip; and
+    * predictions survive a full-model serialization round-trip.
+
+    Architecture-specific paper equations and invariants belong in focused
+    layer tests using ``tests.correctness``.
     :param model:
     :param model_name:
     :param x:
@@ -368,14 +377,14 @@ def check_model(model, model_name, x, y, check_model_io=True):
     model.fit(x, y, batch_size=100, epochs=1, validation_split=0.5)
 
     print(model_name + " test train valid pass!")
+    expected_predictions = predict_numpy(model, x)
     model.save_weights(model_name + '_weights.h5')
     model.load_weights(model_name + '_weights.h5')
     os.remove(model_name + '_weights.h5')
+    assert_nested_allclose(predict_numpy(model, x), expected_predictions)
     print(model_name + " test save load weight pass!")
     if check_model_io:
-        save_model(model, model_name + '.h5')
-        model = load_model(model_name + '.h5', custom_objects)
-        os.remove(model_name + '.h5')
+        model = assert_serialization_predictions(model, x, custom_objects)
         print(model_name + " test save load model pass!")
 
     print(model_name + " test pass!")

--- a/tests/utils_mtl.py
+++ b/tests/utils_mtl.py
@@ -4,10 +4,11 @@ import os
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.keras.models import load_model, save_model
 
 from deepctr.feature_column import SparseFeat, DenseFeat, DEFAULT_GROUP_NAME
 from deepctr.layers import custom_objects
+from tests.correctness import (assert_nested_allclose, assert_serialization_predictions,
+                               predict_numpy)
 
 
 def get_mtl_test_data(sample_size=10, embedding_size=4, sparse_feature_num=1,
@@ -80,14 +81,14 @@ def check_mtl_model(model, model_name, x, y_list, task_types, check_model_io=Tru
     model.fit(x, y_list, batch_size=100, epochs=1, validation_split=0.5)
 
     print(model_name + " test train valid pass!")
+    expected_predictions = predict_numpy(model, x)
     model.save_weights(model_name + '_weights.h5')
     model.load_weights(model_name + '_weights.h5')
     os.remove(model_name + '_weights.h5')
+    assert_nested_allclose(predict_numpy(model, x), expected_predictions)
     print(model_name + " test save load weight pass!")
     if check_model_io:
-        save_model(model, model_name + '.h5')
-        model = load_model(model_name + '.h5', custom_objects)
-        os.remove(model_name + '.h5')
+        model = assert_serialization_predictions(model, x, custom_objects)
         print(model_name + " test save load model pass!")
 
     print(model_name + " test pass!")


### PR DESCRIPTION
## What changed

- add a reusable benchmark suite for single-task, multitask, and sequence models
- add the `benchmarks.onboard` workflow for discovery, scaffolding, wiring audits, verification, and documentation
- integrate OneTrans, FinalMLP, MaskNet, and WuKong, including serializable custom layers
- add a reusable C0-C6 correctness-testing contract:
  - deterministic fixtures
  - independent NumPy reference equations
  - finite and numerical gradients
  - semantic invariants such as masking and causality
  - prediction-equivalent weight and full-model serialization
- make `scaffold --with-layer` generate a correctness-test skeleton and make `verify` run it
- add model tests, benchmark tests, verification reports, docs, and contributor guidance

## Why

Adding a model previously required manually updating several scattered registration, testing, benchmark, serialization, and documentation points. Existing smoke tests also proved that models could run, but not that paper equations, gradients, invariants, or serialization semantics were correct. This change makes onboarding repeatable and adds layered correctness evidence.

## Impact

Contributors can scaffold and verify new CTR models through one CLI workflow. Users gain four recent models, reproducible benchmark tooling, and stronger regression protection across all existing models.

## Validation

- dynamic onboarding audit: **33/33 models fully wired**
- semantic correctness examples: **8 passed** across reference equations, gradients, exact masks, causal invariance, and EDCN deterministic cases
- four new models plus multitask serialization contracts: **14 passed**
- full suite first pass: **171 passed**, with the stricter finite-output contract exposing one random-input EDCN NaN; deterministic fixture added and all four EDCN bridge configurations then passed
- scaffold templates compile and `git diff --check` passes

### Large-sample effectiveness checks

Criteo_x1 2M, CPU, 1 epoch, batch 1024:

| Model | AUC | LogLoss | Train |
| --- | ---: | ---: | ---: |
| MaskNet | 0.7908 | 0.4544 | 41.9s |
| DeepFM | 0.7892 | 0.4559 | 32.6s |
| FinalMLP | 0.7889 | 0.4562 | 32.6s |
| WuKong | 0.7842 | 0.4614 | 61.5s |

MovieLens-25M, 2.28M behavior samples, CPU, 1 epoch, batch 1024:

| Model | AUC | LogLoss | Train |
| --- | ---: | ---: | ---: |
| OneTrans | 0.8056 | 0.5347 | 114.5s |
| DIN | 0.8030 | 0.5375 | 12.4s |

These benchmark numbers validate end-to-end effectiveness under a fixed protocol; equation-level correctness is covered separately by the semantic contracts above.
